### PR TITLE
Rename preflabel and fix ORDO signature

### DIFF
--- a/src/ontology/config/property-map-1.sssom.tsv
+++ b/src/ontology/config/property-map-1.sssom.tsv
@@ -1,3 +1,4 @@
 subject_id	object_id
 http://purl.org/dc/elements/1.1/source	oboInOwl:source
 http://www.w3.org/2004/02/skos/core#prefLabel	http://www.w3.org/2000/01/rdf-schema#label
+http://www.w3.org/2004/02/skos/core#altLabel	oboInOwl:hasExactSynonym

--- a/src/ontology/config/property-map-1.sssom.tsv
+++ b/src/ontology/config/property-map-1.sssom.tsv
@@ -1,2 +1,3 @@
 subject_id	object_id
 http://purl.org/dc/elements/1.1/source	oboInOwl:source
+http://www.w3.org/2004/02/skos/core#prefLabel	http://www.w3.org/2000/01/rdf-schema#label

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -89,7 +89,7 @@ $(COMPONENTSDIR)/doid.owl: $(TMPDIR)/doid_relevant_signature.txt
 		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/doid.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/doid.owl -o $@; fi
 
-ICD10CM_URL="https://data.bioontology.org/ontologies/ICD10CM/submissions/21/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb"
+ICD10CM_URL="https://data.bioontology.org/ontologies/ICD10CM/submissions/22/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb"
 
 component-download-icd10cm.owl: | $(TMPDIR)
 	if [ $(MIR) = true ]; then wget $(ICD10CM_URL) -O $(TMPDIR)/icd10cm.tmp.owl && $(ROBOT) remove -i $(TMPDIR)/icd10cm.tmp.owl --select imports \

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -38,6 +38,8 @@ $(TMPDIR)/ordo_relevant_signature.txt: component-download-ordo.owl | $(TMPDIR)
 # https://github.com/monarch-initiative/omim/issues/60
 $(COMPONENTSDIR)/omim.owl: $(TMPDIR)/omim_relevant_signature.txt
 	if [ $(COMP) = true ]; then $(ROBOT) remove -i $(TMPDIR)/component-download-omim.owl.owl --select imports \
+		rename --mappings config/property-map-1.sssom.tsv --allow-missing-entities true \
+		rename --mappings config/property-map-2.sssom.tsv --allow-missing-entities true \
 		remove -T $(TMPDIR)/omim_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		remove -T config/remove.txt --axioms equivalent \
 		query \
@@ -51,6 +53,8 @@ $(COMPONENTSDIR)/omim.owl: $(TMPDIR)/omim_relevant_signature.txt
 $(COMPONENTSDIR)/ordo.owl: $(TMPDIR)/ordo_relevant_signature.txt config/properties.txt
 	if [ $(COMP) = true ]; then $(ROBOT) remove -i $(TMPDIR)/component-download-ordo.owl.owl --select imports \
 		merge \
+		rename --mappings config/property-map-1.sssom.tsv --allow-missing-entities true \
+		rename --mappings config/property-map-2.sssom.tsv --allow-missing-entities true \
 		query \
 			--update ../sparql/fix_deprecated.ru \
 			--update ../sparql/fix_complex_reification.ru \
@@ -61,12 +65,12 @@ $(COMPONENTSDIR)/ordo.owl: $(TMPDIR)/ordo_relevant_signature.txt config/properti
 			--update ../sparql/ordo-replace-annotation-based-mappings.ru \
 		filter -T $(TMPDIR)/ordo_relevant_signature.txt --trim false \
 		remove -T config/properties.txt --select complement --select properties --trim true \
-		rename --mappings config/property-map-1.sssom.tsv --allow-missing-entities true \
-		rename --mappings config/property-map-2.sssom.tsv --allow-missing-entities true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/ordo.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/ordo.owl -o $@; fi
 
 $(COMPONENTSDIR)/ncit.owl: $(TMPDIR)/ncit_relevant_signature.txt
 	if [ $(COMP) = true ]; then $(ROBOT) remove -i $(TMPDIR)/component-download-ncit.owl.owl --select imports \
+		rename --mappings config/property-map-1.sssom.tsv --allow-missing-entities true \
+		rename --mappings config/property-map-2.sssom.tsv --allow-missing-entities true \
 		remove -T $(TMPDIR)/ncit_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		remove -T config/properties.txt --select complement --select properties --trim true \
 		remove --term "http://purl.obolibrary.org/obo/NCIT_C179199" --axioms "equivalent" \
@@ -74,6 +78,8 @@ $(COMPONENTSDIR)/ncit.owl: $(TMPDIR)/ncit_relevant_signature.txt
 
 $(COMPONENTSDIR)/doid.owl: $(TMPDIR)/doid_relevant_signature.txt
 	if [ $(COMP) = true ]; then $(ROBOT) remove -i $(TMPDIR)/component-download-doid.owl.owl --select imports \
+		rename --mappings config/property-map-1.sssom.tsv --allow-missing-entities true \
+		rename --mappings config/property-map-2.sssom.tsv --allow-missing-entities true \
 		remove -T $(TMPDIR)/doid_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		query \
 			--update ../sparql/fix_omimps.ru \
@@ -104,6 +110,8 @@ $(COMPONENTSDIR)/icd10cm.owl: $(TMPDIR)/icd10cm_relevant_signature.txt
 
 $(COMPONENTSDIR)/icd10who.owl: $(TMPDIR)/icd10who_relevant_signature.txt
 	if [ $(COMP) = true ] ; then $(ROBOT) remove -i $(TMPDIR)/component-download-icd10who.owl.owl --select imports \
+		rename --mappings config/property-map-1.sssom.tsv --allow-missing-entities true \
+		rename --mappings config/property-map-2.sssom.tsv --allow-missing-entities true \
 		remove -T $(TMPDIR)/icd10who_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		remove -T $(TMPDIR)/icd10who_relevant_signature.txt --select individuals \
 		query \

--- a/src/sparql/ordo-relevant-diseases.sparql
+++ b/src/sparql/ordo-relevant-diseases.sparql
@@ -14,8 +14,9 @@ SELECT DISTINCT ?term ?label ?deprecated
 WHERE {
   { 
     { 
-     ?s1 ?p1 ?term . 
-     ?term rdfs:subClassOf* <http://www.orpha.net/ORDO/Orphanet_377788> .
+      VALUES ?ordo_roots {<http://www.orpha.net/ORDO/Orphanet_557493> <http://www.orpha.net/ORDO/Orphanet_557492> <http://www.orpha.net/ORDO/Orphanet_557494>}
+       ?s1 ?p1 ?term .
+       ?term rdfs:subClassOf* ?ordo_roots .
      OPTIONAL {
        ?term rdfs:label ?label
      }
@@ -25,8 +26,9 @@ WHERE {
     }
     UNION
     { 
-      ?term ?p2 ?o2 . 
-      ?term rdfs:subClassOf* <http://www.orpha.net/ORDO/Orphanet_377788> .
+      VALUES ?ordo_roots {<http://www.orpha.net/ORDO/Orphanet_557493> <http://www.orpha.net/ORDO/Orphanet_557492> <http://www.orpha.net/ORDO/Orphanet_557494>}
+      ?term ?p2 ?o2 .
+      ?term rdfs:subClassOf* ?ordo_roots .
       OPTIONAL {
         ?term rdfs:label ?label
       }

--- a/src/sparql/ordo-relevant-signature.sparql
+++ b/src/sparql/ordo-relevant-signature.sparql
@@ -7,8 +7,9 @@ SELECT DISTINCT ?term
 WHERE {
   { 
     { 
+    VALUES ?ordo_roots {<http://www.orpha.net/ORDO/Orphanet_557493> <http://www.orpha.net/ORDO/Orphanet_557492> <http://www.orpha.net/ORDO/Orphanet_557494>}
      ?s1 ?p1 ?term .
-     ?term rdfs:subClassOf* <http://www.orpha.net/ORDO/Orphanet_377788> .
+     ?term rdfs:subClassOf* ?ordo_roots .
      FILTER NOT EXISTS {
        ?term xref: ?xref .
        FILTER(STRSTARTS(str(?xref),"HGNC:"))
@@ -17,8 +18,9 @@ WHERE {
     }
     UNION
     { 
+      VALUES ?ordo_roots {<http://www.orpha.net/ORDO/Orphanet_557493> <http://www.orpha.net/ORDO/Orphanet_557492> <http://www.orpha.net/ORDO/Orphanet_557494>}
       ?term ?p2 ?o2 .
-      ?term rdfs:subClassOf* <http://www.orpha.net/ORDO/Orphanet_377788> .
+      ?term rdfs:subClassOf* ?ordo_roots .
       FILTER NOT EXISTS {
         ?term xref: ?xref .
         FILTER(STRSTARTS(str(?xref),"HGNC:"))


### PR DESCRIPTION
This pull request fixes #67 by expanding the list of relevant diseases to all three clinical branches (see issue). Now, the signature is around what we expect (ca 9K entities). 

This PR also fixes #65 by making sure that all property renamings happen to all ontologies in the set, so that ontologies, for example, that use prefLabel, end up being renamed to `rdfs:label`.