### PR TITLE
updated ncit sparql and exclusion list

### DIFF
--- a/src/ontology/config/ncit_exclusions.tsv
+++ b/src/ontology/config/ncit_exclusions.tsv
@@ -1,1 +1,43 @@
 term_id	term_label	exclusion_reason	exclude_children
+NCIT:134533	Non-Human or Experimental Organism Neoplasm by Organism	MONDO:excludeNonDisease	FALSE
+NCIT:21637	Murine Experimental Organism Diagnosis	MONDO:excludeSpeciesoutofscope	TRUE
+NCIT:134530	Leporine Experimental Organism Diagnosis	MONDO:excludeSpeciesoutofscope	TRUE
+NCIT:134988	Hamster Neoplasm	MONDO:excludeSpeciesoutofscope	TRUE
+NCIT:136555	Gerbil Experimental Organism Diagnosis	MONDO:excludeSpeciesoutofscope	TRUE
+NCIT:134528	Feline Experimental Organism Diagnosis	MONDO:excludeNonDisease	FALSE
+NCIT:134535	Equine Experimental Organism Diagnosis	MONDO:excludeNonDisease	FALSE
+NCIT:134785	Zebra Finch Neoplasm	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134575	Xiphophorus Melanoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134574	Xenopus Neoplasm	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:124251	Woodchuck Hepatocellular Carcinoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:135002	Walleye Dermal Sarcoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:135001	Turtle Neoplasm	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134964	Tamarin Colon Adenocarcinoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134951	Suncus Murinus Mammary Tumor	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:135000	Seal Lymphosarcoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134963	Seal Lymphoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134784	Rhesus Monkey Mammary Tumor	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134783	Rhesus Monkey Lymphoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134999	Rattlesnake Fibroma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:136977	Rainbow Trout Mesothelioma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134573	Rainbow Trout Hepatoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134950	Quail Fibrosarcoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134962	Poeciliopsis Lucida Hepatocellular Carcinoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134949	Pike Sarcoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134572	Medaka Melanoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134571	Medaka Hepatoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134564	Guinea Pig Leukemia	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134563	Guinea Pig Colon Adenocarcinoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134562	Goldfish Erythrophoroma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134774	Gibbon Lymphosarcoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134534	Galline Experimental Organism Diagnosis	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134771	Frog Pronephric Kidney Tumor	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:136559	Fish Experimental Organism Diagnosis	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134769	Duck Neoplasm	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:136978	Devil Facial Tumor Disease	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:135003	Budgerigar Testicular Carcinoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134943	Budgerigar Fibrosarcoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134955	Bat Skin Tumor	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134766	Baboon Lymphoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:134959	Marmoset Lymphoma	MONDO:excludeSpeciesoutofscope	FALSE
+NCIT:182077	Macaca mulatta Hepatocellular Carcinoma	MONDO:excludeSpeciesoutofscope	FALSE

--- a/src/sparql/ncit-relevant-diseases.sparql
+++ b/src/sparql/ncit-relevant-diseases.sparql
@@ -12,10 +12,12 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 # For SNOMED, we are only interested in the Disease or Disorder branch
 SELECT DISTINCT ?term ?label ?deprecated
 WHERE {
-  { 
+VALUES ?roots {<http://purl.obolibrary.org/obo/NCIT_C2991> <http://purl.obolibrary.org/obo/NCIT_C134533>}
+{
+  {
     { 
-     ?s1 ?p1 ?term . 
-     ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/NCIT_C2991> .
+     ?s1 ?p1 ?term .
+     ?term rdfs:subClassOf* ?roots .
      OPTIONAL {
        ?term rdfs:label ?label
      }
@@ -24,9 +26,9 @@ WHERE {
      }
     }
     UNION
-    { 
-      ?term ?p2 ?o2 . 
-      ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/NCIT_C2991> .
+    {
+      ?term ?p2 ?o2 .
+      ?term rdfs:subClassOf* ?roots .
       OPTIONAL {
         ?term rdfs:label ?label
       }

--- a/src/sparql/ncit-relevant-signature.sparql
+++ b/src/sparql/ncit-relevant-signature.sparql
@@ -3,16 +3,18 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 # For SNOMED, we are only interested in the Disease or Disorder branch
 SELECT DISTINCT ?term
 WHERE {
-  { 
-    { 
-     ?s1 ?p1 ?term . 
-     ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/NCIT_C2991> .
+VALUES ?roots {<http://purl.obolibrary.org/obo/NCIT_C2991> <http://purl.obolibrary.org/obo/NCIT_C134533>}
+  {
+    {
+     ?s1 ?p1 ?term .
+     ?term rdfs:subClassOf* ?roots .
     }
     UNION
-    { 
-      ?term ?p2 ?o2 . 
-      ?term rdfs:subClassOf* <http://purl.obolibrary.org/obo/NCIT_C2991> .
+    {
+      ?term ?p2 ?o2 .
+      ?term rdfs:subClassOf* ?roots .
     }
+
   }
   FILTER(isIRI(?term))
 }


### PR DESCRIPTION
Addresses https://github.com/monarch-initiative/mondo/issues/5252

@joeflack4 and @matentzn
I created a new exclusion code : **MONDO:excludeSpeciesoutofscope** 
I added this new exclusion code to our source of truth [here](https://docs.google.com/spreadsheets/d/18V-_j4b22LzCytxFEM3pBEl6-_ODJY06gpUwH0F6JVY/edit#gid=1644570180) and [here](https://mondo.readthedocs.io/en/latest/editors-guide/exclusion-reasons/). It probably needs to be added somewhere in the code (???). I am leaving this part to you.

Please note that I am aware of a term that was "forgotten", and therefore I would expect this term to get imported in Mondo (this is a good way to test that the import works as expected). Please let me know when it is time to review that the import work. Thank you! 