### PR TITLE
Remove object_label from lexical pipeline

### DIFF
--- a/src/scripts/lexmatch-sssom-compare.py
+++ b/src/scripts/lexmatch-sssom-compare.py
@@ -330,7 +330,6 @@ def export_unmatched_exact(unmapped_df, match_type, fn, summary):
         "subject_id": ["ID"],
         "predicate_id": [">A oboInOwl:source"],
         "object_id": ["A oboInOwl:hasDbXref"],
-        "object_label": [">A sssom:object_label"],
     }
     column_seq = unmapped_exact.columns
     unmapped_exact = pd.concat(


### PR DESCRIPTION
@hrshdhgd unfortunately this is not supported by OBO format, so I am removing it. I am assuming that this will prevent this from showing up in the template table?