### PR TITLE
Add preprocess to turn omim xrefs to exact match

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -88,6 +88,7 @@ $(COMPONENTSDIR)/doid.owl: $(TMPDIR)/doid_relevant_signature.txt | component-dow
 			--update ../sparql/fix-labels-with-brackets.ru \
 			--update ../sparql/fix_complex_reification.ru \
 			--update ../sparql/rm_xref_by_prefix.ru \
+			--update ../sparql/fix_make_omim_exact.ru \
 		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/doid.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/doid.owl -o $@; fi
 

--- a/src/sparql/fix_make_omim_exact.ru
+++ b/src/sparql/fix_make_omim_exact.ru
@@ -8,7 +8,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 INSERT {
-  ?entity skos:exactMatch ?value .
+  ?cls skos:exactMatch ?value .
 }
 
 WHERE 

--- a/src/sparql/fix_make_omim_extact.ru
+++ b/src/sparql/fix_make_omim_extact.ru
@@ -1,0 +1,33 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix oio: <http://www.geneontology.org/formats/oboInOwl#>
+prefix def: <http://purl.obolibrary.org/obo/IAO_0000115>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+INSERT {
+  ?entity skos:exactMatch ?value .
+}
+
+WHERE 
+{  
+  ?cls a owl:Class; 
+     	oboInOwl:hasDbXref ?value .
+  
+  FILTER NOT EXISTS {
+  	?cls owl:deprecated ?deprecated .
+  }
+  
+  # Only make the "exactMatch" assumption of 1:1.
+  FILTER NOT EXISTS {
+  	?cls oboInOwl:hasDbXref ?value2 .
+    FILTER( STRSTARTS(str(?value2), "OMIM"))
+    FILTER(?value!=?value2)
+  }
+  
+  FILTER( STRSTARTS(str(?value), "OMIM"))
+  FILTER( !isBlank(?cls) && STRSTARTS(str(?cls), "http://purl.obolibrary.org/obo/DOID_"))
+  
+}


### PR DESCRIPTION
This could allow us to use the current lexmatch pipeline to identify DOID matches via OMIM.

@sabrinatoro FYI there were plenty of chases where 1 DO term is mapped to multiple OMIM terms - we basically exclude this now from the process. Only 1:1 mappings are considered.