### PR TITLE
Bugfix: OMIMPS children

### DIFF
--- a/src/ontology/slurp/omim.tsv
+++ b/src/ontology/slurp/omim.tsv
@@ -5,4 +5,275 @@ MONDO:0859315	fatty liver disease, protection from	OMIM:620116	MONDO:equivalentT
 MONDO:0859359	blood group, er	OMIM:620207	MONDO:equivalentTo	blood group, er		
 MONDO:0859389	knobloch syndrome	OMIMPS:267750	MONDO:equivalentTo	Knobloch syndrome		
 MONDO:0859563	hyper-ige recurrent infection syndrome 1, autosomal dominant	OMIM:147060	MONDO:equivalentTo	hyper-ige recurrent infection syndrome 1, autosomal dominant		MONDO:0018037
-MONDO:0859566	pulmonary disease, chronic obstructive	OMIM:606963	MONDO:equivalentTo	pulmonary disease, chronic obstructive		
+MONDO:0859767	rhabdomyosarcoma, embryonal, 2	OMIM:180295	MONDO:equivalentTo	rhabdomyosarcoma, embryonal, 2		
+MONDO:0859768	schistosoma mansoni infection, susceptibility/resistance to	OMIM:181460	MONDO:equivalentTo	schistosoma mansoni infection, susceptibility/resistance to		
+MONDO:0859769	intellectual developmental disorder, x-linked, syndromic, with pigmentary mosaicism and coarse facies	OMIM:301066	MONDO:equivalentTo	intellectual developmental disorder, x-linked, syndromic, with pigmentary mosaicism and coarse facies		
+MONDO:0859770	chromosome xq13 duplication syndrome	OMIM:301069	MONDO:equivalentTo	chromosome xq13 duplication syndrome		
+MONDO:0859771	thrombophilia, x-linked, due to factor 8 defect	OMIM:301071	MONDO:equivalentTo	thrombophilia, x-linked, due to factor 8 defect		
+MONDO:0859772	systemic lupus erythematosus 17	OMIM:301080	MONDO:equivalentTo	systemic lupus erythematosus 17		
+MONDO:0859773	neurodevelopmental disorder with gait disturbance, dysmorphic facies, and behavioral abnormalities, x-linked	OMIM:301094	MONDO:equivalentTo	neurodevelopmental disorder with gait disturbance, dysmorphic facies, and behavioral abnormalities, X-linked		
+MONDO:0859774	intellectual developmental disorder, x-linked 110	OMIM:301095	MONDO:equivalentTo	intellectual developmental disorder, X-linked 110		MONDO:0019181
+MONDO:0859775	spermatogenic failure, x-linked, 5	OMIM:301099	MONDO:equivalentTo	spermatogenic failure, x-linked, 5		MONDO:0004983
+MONDO:0859776	spermatogenic failure, x-linked, 6	OMIM:301101	MONDO:equivalentTo	spermatogenic failure, x-linked, 6		MONDO:0004983
+MONDO:0859777	psoriatic arthritis, susceptibility to	OMIM:607507	MONDO:equivalentTo	psoriatic arthritis, susceptibility to		
+MONDO:0859778	alzahrani-kuwahara syndrome	OMIM:619268	MONDO:equivalentTo	alzahrani-kuwahara syndrome		
+MONDO:0859779	neurodevelopmental disorder with spasticity, cataracts, and cerebellar hypoplasia	OMIM:619286	MONDO:equivalentTo	neurodevelopmental disorder with spasticity, cataracts, and cerebellar hypoplasia		
+MONDO:0859780	mahvash disease	OMIM:619290	MONDO:equivalentTo	mahvash disease		
+MONDO:0859781	blepharophimosis-impaired intellectual development syndrome	OMIM:619293	MONDO:equivalentTo	blepharophimosis-impaired intellectual development syndrome		
+MONDO:0859782	kinsship syndrome	OMIM:619297	MONDO:equivalentTo	kinsship syndrome		
+MONDO:0859783	neurodevelopmental disorder with dysmorphic facies and cerebellar hypoplasia	OMIM:619306	MONDO:equivalentTo	neurodevelopmental disorder with dysmorphic facies and cerebellar hypoplasia		
+MONDO:0859784	hiatt-neu-cooper neurodevelopmental syndrome	OMIM:619311	MONDO:equivalentTo	hiatt-neu-cooper neurodevelopmental syndrome		
+MONDO:0859785	radio-tartaglia syndrome	OMIM:619312	MONDO:equivalentTo	radio-tartaglia syndrome		
+MONDO:0859786	buratti-harel syndrome	OMIM:619314	MONDO:equivalentTo	buratti-harel syndrome		
+MONDO:0859787	oculogastrointestinal neurodevelopmental syndrome	OMIM:619318	MONDO:equivalentTo	oculogastrointestinal neurodevelopmental syndrome		
+MONDO:0859788	growth restriction, hypoplastic kidneys, alopecia, and distinctive facies	OMIM:619321	MONDO:equivalentTo	growth restriction, hypoplastic kidneys, alopecia, and distinctive facies		
+MONDO:0859789	marbach-rustad progeroid syndrome	OMIM:619322	MONDO:equivalentTo	marbach-rustad progeroid syndrome		
+MONDO:0859790	neurodevelopmental disorder with seizures and gingival overgrowth	OMIM:619323	MONDO:equivalentTo	neurodevelopmental disorder with seizures and gingival overgrowth		
+MONDO:0859791	hypertriglyceridemia 2	OMIM:619324	MONDO:equivalentTo	hypertriglyceridemia 2		
+MONDO:0859792	bdv syndrome	OMIM:619326	MONDO:equivalentTo	bdv syndrome		
+MONDO:0859793	fibromuscular dysplasia, multifocal	OMIM:619329	MONDO:equivalentTo	fibromuscular dysplasia, multifocal		
+MONDO:0859794	neurodevelopmental disorder with cerebellar atrophy and motor dysfunction	OMIM:619333	MONDO:equivalentTo	neurodevelopmental disorder with cerebellar atrophy and motor dysfunction		
+MONDO:0859795	cataracts, spastic paraparesis, and speech delay	OMIM:619338	MONDO:equivalentTo	cataracts, spastic paraparesis, and speech delay		
+MONDO:0859796	bartsocas-papas syndrome 2	OMIM:619339	MONDO:equivalentTo	bartsocas-papas syndrome 2		
+MONDO:0859797	chromosome 1p36 deletion syndrome, proximal	OMIM:619343	MONDO:equivalentTo	chromosome 1p36 deletion syndrome, proximal		
+MONDO:0859798	dysostosis multiplex, ain-naz  iia	OMIM:619345	MONDO:equivalentTo	dysostosis multiplex, ain-naz  iia		
+MONDO:0859799	visceral myopathy 2	OMIM:619350	MONDO:equivalentTo	visceral myopathy 2		
+MONDO:0859800	ataxia, intention tremor, and hypotonia syndrome, childhood-onset	OMIM:619352	MONDO:equivalentTo	ataxia, intention tremor, and hypotonia syndrome, childhood-onset		
+MONDO:0859801	deafness, cataract, impaired intellectual development, and polyneuropathy	OMIM:619354	MONDO:equivalentTo	deafness, cataract, impaired intellectual development, and polyneuropathy		
+MONDO:0859802	mitochondrial complex 4 deficiency, nuclear  iia 22	OMIM:619355	MONDO:equivalentTo	mitochondrial complex 4 deficiency, nuclear  iia 22		MONDO:0033885
+MONDO:0859803	onychodystrophy, osteodystrophy, impaired intellectual development, and seizures syndrome	OMIM:619356	MONDO:equivalentTo	onychodystrophy, osteodystrophy, impaired intellectual development, and seizures syndrome		
+MONDO:0859804	neurodevelopmental disorder with infantile epileptic spasms	OMIM:619373	MONDO:equivalentTo	neurodevelopmental disorder with infantile epileptic spasms		
+MONDO:0859805	faundes-banka syndrome	OMIM:619376	MONDO:equivalentTo	faundes-banka syndrome		
+MONDO:0859806	osteootohepatoenteric syndrome	OMIM:619377	MONDO:equivalentTo	osteootohepatoenteric syndrome		
+MONDO:0859807	neurodevelopmental disorder with hypotonia, facial dysmorphism, and brain abnormalities	OMIM:619383	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia, facial dysmorphism, and brain abnormalities		
+MONDO:0859808	visceral leiomyopathy, african degenerative	OMIM:619400	MONDO:equivalentTo	visceral leiomyopathy, african degenerative		
+MONDO:0859809	hypokalemic tubulopathy and deafness	OMIM:619406	MONDO:equivalentTo	hypokalemic tubulopathy and deafness		
+MONDO:0859810	myopathy, myofibrillar, 12, infantile-onset, with cardiomyopathy	OMIM:619424	MONDO:equivalentTo	myopathy, myofibrillar, 12, infantile-onset, with cardiomyopathy		
+MONDO:0859811	white-kernohan syndrome	OMIM:619426	MONDO:equivalentTo	white-kernohan syndrome		
+MONDO:0859812	retinal dystrophy and microvillus inclusion disease	OMIM:619446	MONDO:equivalentTo	retinal dystrophy and microvillus inclusion disease		
+MONDO:0859813	luo-schoch-yamamoto syndrome	OMIM:619460	MONDO:equivalentTo	luo-schoch-yamamoto syndrome		
+MONDO:0859814	hemolytic disease of fetus and newborn, rh-induced	OMIM:619462	MONDO:equivalentTo	hemolytic disease of fetus and newborn, rh-induced		
+MONDO:0859815	sick sinus syndrome 4	OMIM:619464	MONDO:equivalentTo	sick sinus syndrome 4		
+MONDO:0859816	usmani-riazuddin syndrome, autosomal dominant	OMIM:619467	MONDO:equivalentTo	usmani-riazuddin syndrome, autosomal dominant		
+MONDO:0859817	nephronophthisis-like nephropathy 2	OMIM:619468	MONDO:equivalentTo	nephronophthisis-like nephropathy 2		
+MONDO:0859818	neurodevelopmental disorder with motor and speech delay and behavioral abnormalities	OMIM:619470	MONDO:equivalentTo	neurodevelopmental disorder with motor and speech delay and behavioral abnormalities		
+MONDO:0859819	viss syndrome	OMIM:619472	MONDO:equivalentTo	viss syndrome		
+MONDO:0859820	developmental delay, impaired speech, and behavioral abnormalities	OMIM:619475	MONDO:equivalentTo	developmental delay, impaired speech, and behavioral abnormalities		
+MONDO:0859821	neurodevelopmental disorder with dysmorphic facies and thin corpus callosum	OMIM:619480	MONDO:equivalentTo	neurodevelopmental disorder with dysmorphic facies and thin corpus callosum		
+MONDO:0859822	bile acid malabsorption, primary, 2	OMIM:619481	MONDO:equivalentTo	bile acid malabsorption, primary, 2		
+MONDO:0859823	degcags syndrome	OMIM:619488	MONDO:equivalentTo	degcags syndrome		
+MONDO:0859824	short stature, dauber-argente  iia	OMIM:619489	MONDO:equivalentTo	short stature, dauber-argente  iia		
+MONDO:0859825	parkinson disease 24, autosomal dominant, susceptibility to	OMIM:619491	MONDO:equivalentTo	parkinson disease 24, autosomal dominant, susceptibility to		
+MONDO:0859826	ventriculomegaly and arthrogryposis	OMIM:619501	MONDO:equivalentTo	ventriculomegaly and arthrogryposis		
+MONDO:0859827	neurodevelopmental disorder with hypotonia and dysmorphic facies	OMIM:619503	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia and dysmorphic facies		
+MONDO:0859828	chopra-amiel-gordon syndrome	OMIM:619504	MONDO:equivalentTo	chopra-amiel-gordon syndrome		
+MONDO:0859829	neurodevelopmental disorder with hypotonia and brain abnormalities	OMIM:619512	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia and brain abnormalities		
+MONDO:0859830	neurodevelopmental disorder with seizures and brain abnormalities	OMIM:619517	MONDO:equivalentTo	neurodevelopmental disorder with seizures and brain abnormalities		
+MONDO:0859831	muscular dystrophy, congenital hearing loss, and ovarian insufficiency syndrome	OMIM:619518	MONDO:equivalentTo	muscular dystrophy, congenital hearing loss, and ovarian insufficiency syndrome		
+MONDO:0859832	neurodevelopmental-craniofacial syndrome with variable renal and cardiac abnormalities	OMIM:619522	MONDO:equivalentTo	neurodevelopmental-craniofacial syndrome with variable renal and cardiac abnormalities		
+MONDO:0859833	biliary, renal, neurologic, and skeletal syndrome	OMIM:619534	MONDO:equivalentTo	biliary, renal, neurologic, and skeletal syndrome		
+MONDO:0859834	cerebral cavernous malformations 4	OMIM:619538	MONDO:equivalentTo	cerebral cavernous malformations 4		
+MONDO:0859835	neuroocular syndrome	OMIM:619539	MONDO:equivalentTo	neuroocular syndrome		
+MONDO:0859836	boudin-mortier syndrome	OMIM:619543	MONDO:equivalentTo	boudin-mortier syndrome		
+MONDO:0859837	usmani-riazuddin syndrome, autosomal recessive	OMIM:619548	MONDO:equivalentTo	usmani-riazuddin syndrome, autosomal recessive		
+MONDO:0859838	intellectual developmental disorder with hypotonia, impaired speech, and dysmorphic facies	OMIM:619556	MONDO:equivalentTo	intellectual developmental disorder with hypotonia, impaired speech, and dysmorphic facies		
+MONDO:0859839	short stature, impaired intellectual development, microcephaly, hypotonia, and ocular anomalies	OMIM:619557	MONDO:equivalentTo	short stature, impaired intellectual development, microcephaly, hypotonia, and ocular anomalies		
+MONDO:0859840	developmental delay with or without intellectual impairment or behavioral abnormalities	OMIM:619575	MONDO:equivalentTo	developmental delay with or without intellectual impairment or behavioral abnormalities		
+MONDO:0859841	cerebellar ataxia, brain abnormalities, and cardiac conduction defects	OMIM:619576	MONDO:equivalentTo	cerebellar ataxia, brain abnormalities, and cardiac conduction defects		
+MONDO:0859842	neurodevelopmental disorder with impaired language and ataxia and with or without seizures	OMIM:619580	MONDO:equivalentTo	neurodevelopmental disorder with impaired language and ataxia and with or without seizures		
+MONDO:0859843	developmental delay, hypotonia, musculoskeletal defects, and behavioral abnormalities	OMIM:619595	MONDO:equivalentTo	developmental delay, hypotonia, musculoskeletal defects, and behavioral abnormalities		
+MONDO:0859844	rhizomelic dysplasia, ain-naz  iia	OMIM:619598	MONDO:equivalentTo	rhizomelic dysplasia, ain-naz  iia		
+MONDO:0859845	fetal akinesia, respiratory insufficiency, microcephaly, polymicrogyria, and dysmorphic facies	OMIM:619602	MONDO:equivalentTo	fetal akinesia, respiratory insufficiency, microcephaly, polymicrogyria, and dysmorphic facies		
+MONDO:0859846	delayed puberty, self-limited	OMIM:619613	MONDO:equivalentTo	delayed puberty, self-limited		
+MONDO:0859847	neurodevelopmental disorder with hearing loss and spasticity	OMIM:619616	MONDO:equivalentTo	neurodevelopmental disorder with hearing loss and spasticity		
+MONDO:0859848	neurodevelopmental disorder with hypotonia and gross motor and speech delay	OMIM:619639	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia and gross motor and speech delay		
+MONDO:0859849	hengel-maroofian-schols syndrome	OMIM:619641	MONDO:equivalentTo	hengel-maroofian-schols syndrome		
+MONDO:0859850	zaki syndrome	OMIM:619648	MONDO:equivalentTo	zaki syndrome		
+MONDO:0859851	chromosome 16q12 duplication syndrome	OMIM:619649	MONDO:equivalentTo	chromosome 16q12 duplication syndrome		
+MONDO:0859852	neurodevelopmental disorder with hyperkinetic movements and dyskinesia	OMIM:619651	MONDO:equivalentTo	neurodevelopmental disorder with hyperkinetic movements and dyskinesia		
+MONDO:0859853	neurodevelopmental disorder, nonprogressive, with spasticity and transient opisthotonus	OMIM:619653	MONDO:equivalentTo	neurodevelopmental disorder, nonprogressive, with spasticity and transient opisthotonus		
+MONDO:0859854	congenital heart defects, multiple types, 8, with or without heterotaxy	OMIM:619657	MONDO:equivalentTo	congenital heart defects, multiple types, 8, with or without heterotaxy		
+MONDO:0859855	marbach-schaaf neurodevelopmental syndrome	OMIM:619680	MONDO:equivalentTo	marbach-schaaf neurodevelopmental syndrome		
+MONDO:0859856	dystonia, early-onset, and/or spastic paraplegia	OMIM:619681	MONDO:equivalentTo	dystonia, early-onset, and/or spastic paraplegia		
+MONDO:0859857	neurodevelopmental disorder with microcephaly, seizures, and neonatal cholestasis	OMIM:619685	MONDO:equivalentTo	neurodevelopmental disorder with microcephaly, seizures, and neonatal cholestasis		
+MONDO:0859858	brunet-wagner neurodevelopmental syndrome	OMIM:619690	MONDO:equivalentTo	brunet-wagner neurodevelopmental syndrome		
+MONDO:0859859	developmental delay with variable neurologic and brain abnormalities	OMIM:619694	MONDO:equivalentTo	developmental delay with variable neurologic and brain abnormalities		
+MONDO:0859860	rauch-steindl syndrome	OMIM:619695	MONDO:equivalentTo	rauch-steindl syndrome		
+MONDO:0859861	ferguson-bonni neurodevelopmental syndrome	OMIM:619699	MONDO:equivalentTo	ferguson-bonni neurodevelopmental syndrome		
+MONDO:0859862	yoon-bellen neurodevelopmental syndrome	OMIM:619701	MONDO:equivalentTo	yoon-bellen neurodevelopmental syndrome		
+MONDO:0859863	heterotaxy, visceral, 12, autosomal	OMIM:619702	MONDO:equivalentTo	heterotaxy, visceral, 12, autosomal		
+MONDO:0859864	congenital disorder of glycosylation,  iia iw, autosomal dominant	OMIM:619714	MONDO:equivalentTo	congenital disorder of glycosylation,  iia iw, autosomal dominant		
+MONDO:0859865	intellectual disability and myopathy syndrome	OMIM:619719	MONDO:equivalentTo	intellectual disability and myopathy syndrome		
+MONDO:0859866	neurodevelopmental disorder with or without variable movement or behavioral abnormalities	OMIM:619725	MONDO:equivalentTo	neurodevelopmental disorder with or without variable movement or behavioral abnormalities		
+MONDO:0859867	craniotubular dysplasia, ikegawa  iia	OMIM:619727	MONDO:equivalentTo	craniotubular dysplasia, ikegawa  iia		
+MONDO:0859868	inclusion body myopathy and brain white matter abnormalities	OMIM:619733	MONDO:equivalentTo	inclusion body myopathy and brain white matter abnormalities		
+MONDO:0859869	combined oxidative phosphorylation deficiency 55	OMIM:619743	MONDO:equivalentTo	combined oxidative phosphorylation deficiency 55		MONDO:0000732
+MONDO:0859870	cerebellar dysfunction, impaired intellectual development, and hypogonadotropic hypogonadism	OMIM:619761	MONDO:equivalentTo	cerebellar dysfunction, impaired intellectual development, and hypogonadotropic hypogonadism		
+MONDO:0859871	kury-isidor syndrome	OMIM:619762	MONDO:equivalentTo	kury-isidor syndrome		
+MONDO:0859872	macrocephaly, neurodevelopmental delay, lymphoid hyperplasia, and persistent fetal hemoglobin	OMIM:619769	MONDO:equivalentTo	macrocephaly, neurodevelopmental delay, lymphoid hyperplasia, and persistent fetal hemoglobin		
+MONDO:0859873	neurodevelopmental disorder with central hypotonia and dysmorphic facies	OMIM:619797	MONDO:equivalentTo	neurodevelopmental disorder with central hypotonia and dysmorphic facies		
+MONDO:0859874	epidermolysis bullosa, junctional 6, with pyloric atresia	OMIM:619817	MONDO:equivalentTo	epidermolysis bullosa, junctional 6, with pyloric atresia		
+MONDO:0859875	agammaglobulinemia 8b, autosomal recessive	OMIM:619824	MONDO:equivalentTo	agammaglobulinemia 8b, autosomal recessive		
+MONDO:0859876	auditory neuropathy, autosomal dominant 3	OMIM:619832	MONDO:equivalentTo	auditory neuropathy, autosomal dominant 3		
+MONDO:0859877	neurodevelopmental disorder with neuromuscular and skeletal abnormalities	OMIM:619833	MONDO:equivalentTo	neurodevelopmental disorder with neuromuscular and skeletal abnormalities		
+MONDO:0859878	3-methylglutaconic aciduria,  iia 7a	OMIM:619835	MONDO:equivalentTo	3-methylglutaconic aciduria,  iia 7a		
+MONDO:0859879	hypoalphalipoproteinemia, primary, 2, intermediate	OMIM:619836	MONDO:equivalentTo	hypoalphalipoproteinemia, primary, 2, intermediate		
+MONDO:0859880	chilton-okur-chung neurodevelopmental syndrome	OMIM:619841	MONDO:equivalentTo	chilton-okur-chung neurodevelopmental syndrome		
+MONDO:0859881	intellectual developmental disorder with or without peripheral neuropathy	OMIM:619844	MONDO:equivalentTo	intellectual developmental disorder with or without peripheral neuropathy		
+MONDO:0859882	neurodegeneration, childhood-onset, with progressive microcephaly	OMIM:619847	MONDO:equivalentTo	neurodegeneration, childhood-onset, with progressive microcephaly		
+MONDO:0859883	leukodystrophy, hypomyelinating, 24	OMIM:619851	MONDO:equivalentTo	leukodystrophy, hypomyelinating, 24		MONDO:0019046
+MONDO:0859884	neurodevelopmental disorder with hypotonia, impaired speech, and behavioral abnormalities	OMIM:619854	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia, impaired speech, and behavioral abnormalities		
+MONDO:0859885	phosphoribosylaminoimidazole carboxylase deficiency	OMIM:619859	MONDO:equivalentTo	phosphoribosylaminoimidazole carboxylase deficiency		
+MONDO:0859886	spinocerebellar ataxia, autosomal recessive 32	OMIM:619862	MONDO:equivalentTo	spinocerebellar ataxia, autosomal recessive 32		MONDO:0015244
+MONDO:0859887	leukodystrophy, childhood-onset, remitting	OMIM:619864	MONDO:equivalentTo	leukodystrophy, childhood-onset, remitting		
+MONDO:0859888	neurocardiofaciodigital syndrome	OMIM:619869	MONDO:equivalentTo	neurocardiofaciodigital syndrome		
+MONDO:0859889	corneal dystrophy, punctiform and polychromatic pre-descemet	OMIM:619871	MONDO:equivalentTo	corneal dystrophy, punctiform and polychromatic pre-descemet		
+MONDO:0859890	parenti-mignot neurodevelopmental syndrome	OMIM:619873	MONDO:equivalentTo	parenti-mignot neurodevelopmental syndrome		
+MONDO:0859891	neurodevelopmental disorder with microcephaly, hypotonia, nystagmus, and seizures	OMIM:619876	MONDO:equivalentTo	neurodevelopmental disorder with microcephaly, hypotonia, nystagmus, and seizures		
+MONDO:0859892	dentici-novelli neurodevelopmental syndrome	OMIM:619877	MONDO:equivalentTo	dentici-novelli neurodevelopmental syndrome		
+MONDO:0859893	neurodevelopmental disorder with poor growth and skeletal anomalies	OMIM:619880	MONDO:equivalentTo	neurodevelopmental disorder with poor growth and skeletal anomalies		
+MONDO:0859894	osteoporosis, childhood- or juvenile-onset, with developmental delay	OMIM:619884	MONDO:equivalentTo	osteoporosis, childhood- or juvenile-onset, with developmental delay		
+MONDO:0859895	hepatorenocardiac degenerative fibrosis	OMIM:619902	MONDO:equivalentTo	hepatorenocardiac degenerative fibrosis		
+MONDO:0859896	peripheral motor neuropathy, childhood-onset, biotin-responsive	OMIM:619903	MONDO:equivalentTo	peripheral motor neuropathy, childhood-onset, biotin-responsive		
+MONDO:0859897	neurodevelopmental disorder with language delay and seizures	OMIM:619908	MONDO:equivalentTo	neurodevelopmental disorder with language delay and seizures		
+MONDO:0859898	intellectual developmental disorder with language impairment and early-onset dopa-responsive dystonia-parkinsonism	OMIM:619911	MONDO:equivalentTo	intellectual developmental disorder with language impairment and early-onset dopa-responsive dystonia-parkinsonism		
+MONDO:0859899	neurodevelopmental disorder with dystonia and seizures	OMIM:619922	MONDO:equivalentTo	neurodevelopmental disorder with dystonia and seizures		
+MONDO:0859900	dworschak-punetha neurodevelopmental syndrome	OMIM:619955	MONDO:equivalentTo	dworschak-punetha neurodevelopmental syndrome		
+MONDO:0859901	attention deficit-hyperactivity disorder 8	OMIM:619957	MONDO:equivalentTo	attention deficit-hyperactivity disorder 8		
+MONDO:0859902	acces syndrome	OMIM:619959	MONDO:equivalentTo	acces syndrome		
+MONDO:0859903	developmental delay, impaired speech, and behavioral abnormalities, with or without seizures	OMIM:619964	MONDO:equivalentTo	developmental delay, impaired speech, and behavioral abnormalities, with or without seizures		
+MONDO:0859904	neurodevelopmental disorder with epilepsy and brain atrophy	OMIM:619971	MONDO:equivalentTo	neurodevelopmental disorder with epilepsy and brain atrophy		
+MONDO:0859905	neurodevelopmental disorder with severe motor impairment, absent language, cerebral hypomyelination, and brain atrophy	OMIM:619972	MONDO:equivalentTo	neurodevelopmental disorder with severe motor impairment, absent language, cerebral hypomyelination, and brain atrophy		
+MONDO:0859906	tumor predisposition syndrome 2	OMIM:619975	MONDO:equivalentTo	tumor predisposition syndrome 2		
+MONDO:0859907	macular dystrophy, retinal, 4	OMIM:619977	MONDO:equivalentTo	macular dystrophy, retinal, 4		MONDO:0031166
+MONDO:0859908	braddock-carey syndrome 1	OMIM:619980	MONDO:equivalentTo	braddock-carey syndrome 1		MONDO:0031646
+MONDO:0859909	braddock-carey syndrome 2	OMIM:619981	MONDO:equivalentTo	braddock-carey syndrome 2		MONDO:0031646
+MONDO:0859910	glycosylphosphatidylinositol biosynthesis defect 25	OMIM:619985	MONDO:equivalentTo	glycosylphosphatidylinositol biosynthesis defect 25		
+MONDO:0859911	neurodevelopmental disorder with speech delay and variable ocular anomalies	OMIM:619989	MONDO:equivalentTo	neurodevelopmental disorder with speech delay and variable ocular anomalies		
+MONDO:0859912	liver disease, severe congenital	OMIM:619991	MONDO:equivalentTo	liver disease, severe congenital		
+MONDO:0859913	neurodevelopmental disorder with intention tremor, pyramidal signs, dyspraxia, and ocular anomalies	OMIM:619995	MONDO:equivalentTo	neurodevelopmental disorder with intention tremor, pyramidal signs, dyspraxia, and ocular anomalies		
+MONDO:0859914	neurodevelopmental disorder with spasticity, seizures, and brain abnormalities	OMIM:620001	MONDO:equivalentTo	neurodevelopmental disorder with spasticity, seizures, and brain abnormalities		
+MONDO:0859915	primordial dwarfism-immunodeficiency-lipodystrophy syndrome	OMIM:620005	MONDO:equivalentTo	primordial dwarfism-immunodeficiency-lipodystrophy syndrome		
+MONDO:0859916	intellectual developmental disorder with muscle tone abnormalities and distal skeletal defects	OMIM:620007	MONDO:equivalentTo	intellectual developmental disorder with muscle tone abnormalities and distal skeletal defects		
+MONDO:0859917	keratoderma-ichthyosis-deafness syndrome, autosomal recessive	OMIM:620009	MONDO:equivalentTo	keratoderma-ichthyosis-deafness syndrome, autosomal recessive		
+MONDO:0859918	spinal muscular atrophy, distal, autosomal recessive, 6	OMIM:620011	MONDO:equivalentTo	spinal muscular atrophy, distal, autosomal recessive, 6		
+MONDO:0859919	developmental delay, hypotonia, and impaired language	OMIM:620012	MONDO:equivalentTo	developmental delay, hypotonia, and impaired language		
+MONDO:0859920	intellectual developmental disorder with autism and dysmorphic facies	OMIM:620021	MONDO:equivalentTo	intellectual developmental disorder with autism and dysmorphic facies		
+MONDO:0859921	neurodevelopmental disorder with microcephaly, movement abnormalities, and seizures	OMIM:620023	MONDO:equivalentTo	neurodevelopmental disorder with microcephaly, movement abnormalities, and seizures		
+MONDO:0859922	neurodevelopmental disorder with seizures, microcephaly, and brain abnormalities	OMIM:620024	MONDO:equivalentTo	neurodevelopmental disorder with seizures, microcephaly, and brain abnormalities		
+MONDO:0859923	diaphragmatic hernia 4, with cardiovascular defects	OMIM:620025	MONDO:equivalentTo	diaphragmatic hernia 4, with cardiovascular defects		MONDO:0005711
+MONDO:0859924	neurodevelopmental disorder with microcephaly, short stature, and speech delay	OMIM:620027	MONDO:equivalentTo	neurodevelopmental disorder with microcephaly, short stature, and speech delay		
+MONDO:0859925	neurodevelopmental disorder with hypotonia, language delay, and skeletal defects with or without seizures	OMIM:620029	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia, language delay, and skeletal defects with or without seizures		
+MONDO:0859926	neurodevelopmental disorder with microcephaly, hypotonia, and absent language	OMIM:620038	MONDO:equivalentTo	neurodevelopmental disorder with microcephaly, hypotonia, and absent language		
+MONDO:0859927	bone marrow failure and diabetes mellitus syndrome	OMIM:620044	MONDO:equivalentTo	bone marrow failure and diabetes mellitus syndrome		
+MONDO:0859928	intestinal dysmotility syndrome	OMIM:620045	MONDO:equivalentTo	intestinal dysmotility syndrome		
+MONDO:0859929	familial apolipoprotein gene cluster deletion syndrome	OMIM:620058	MONDO:equivalentTo	familial apolipoprotein gene cluster deletion syndrome		
+MONDO:0859930	developmental delay, behavioral abnormalities, and neuropsychiatric disorders	OMIM:620065	MONDO:equivalentTo	developmental delay, behavioral abnormalities, and neuropsychiatric disorders		
+MONDO:0859931	neurodevelopmental disorder with microcephaly, cerebral atrophy, and visual impairment	OMIM:620066	MONDO:equivalentTo	neurodevelopmental disorder with microcephaly, cerebral atrophy, and visual impairment		
+MONDO:0859932	cardiac valvular dysplasia 2	OMIM:620067	MONDO:equivalentTo	cardiac valvular dysplasia 2		MONDO:0031323
+MONDO:0859933	neurodevelopmental disorder with short stature, prominent forehead, and feeding difficulties	OMIM:620070	MONDO:equivalentTo	neurodevelopmental disorder with short stature, prominent forehead, and feeding difficulties		
+MONDO:0859934	neurodevelopmental disorder with poor growth, spastic tetraplegia, and hearing loss	OMIM:620071	MONDO:equivalentTo	neurodevelopmental disorder with poor growth, spastic tetraplegia, and hearing loss		
+MONDO:0859935	neurodevelopmental disorder with dysmorphic facies and skeletal and brain abnormalities	OMIM:620073	MONDO:equivalentTo	neurodevelopmental disorder with dysmorphic facies and skeletal and brain abnormalities		
+MONDO:0859936	neurodevelopmental disorder with facial dysmorphism, absent language, and pseudo-pelger-huet anomaly	OMIM:620075	MONDO:equivalentTo	neurodevelopmental disorder with facial dysmorphism, absent language, and pseudo-pelger-huet anomaly		
+MONDO:0859937	bent bone dysplasia syndrome 2	OMIM:620076	MONDO:equivalentTo	bent bone dysplasia syndrome 2		MONDO:0031615
+MONDO:0859938	neuronopathy, distal hereditary motor,  iia 10	OMIM:620080	MONDO:equivalentTo	neuronopathy, distal hereditary motor,  iia 10		
+MONDO:0859939	neurodevelopmental disorder with craniofacial dysmorphism and skeletal defects	OMIM:620083	MONDO:equivalentTo	neurodevelopmental disorder with craniofacial dysmorphism and skeletal defects		
+MONDO:0859940	hypermetabolism due to uncoupled mitochondrial oxidative phosphorylation 2	OMIM:620085	MONDO:equivalentTo	hypermetabolism due to uncoupled mitochondrial oxidative phosphorylation 2		
+MONDO:0859941	intellectual developmental disorder with ocular anomalies and distinctive facial features	OMIM:620086	MONDO:equivalentTo	intellectual developmental disorder with ocular anomalies and distinctive facial features		
+MONDO:0859942	neurodegeneration, childhood-onset, with multisystem involvement due to mitochondrial dysfunction	OMIM:620089	MONDO:equivalentTo	neurodegeneration, childhood-onset, with multisystem involvement due to mitochondrial dysfunction		
+MONDO:0859943	neurodevelopmental disorder with eye movement abnormalities and ataxia	OMIM:620094	MONDO:equivalentTo	neurodevelopmental disorder with eye movement abnormalities and ataxia		
+MONDO:0859944	developmental delay with variable intellectual disability and dysmorphic facies	OMIM:620098	MONDO:equivalentTo	developmental delay with variable intellectual disability and dysmorphic facies		
+MONDO:0859945	cleidocranial dysplasia 2	OMIM:620099	MONDO:equivalentTo	cleidocranial dysplasia 2		
+MONDO:0859946	retinitis pigmentosa 95	OMIM:620102	MONDO:equivalentTo	retinitis pigmentosa 95		MONDO:0019200
+MONDO:0859947	spastic paraplegia 88, autosomal dominant	OMIM:620106	MONDO:equivalentTo	spastic paraplegia 88, autosomal dominant		MONDO:0019064
+MONDO:0859948	orofaciodigital syndrome 19	OMIM:620107	MONDO:equivalentTo	orofaciodigital syndrome 19		
+MONDO:0859949	charcot-marie-tooth disease, demyelinating,  iia 1j	OMIM:620111	MONDO:equivalentTo	charcot-marie-tooth disease, demyelinating,  iia 1j		MONDO:0015626
+MONDO:0859950	neurodevelopmental disorder with growth retardation, dysmorphic facies, and corpus callosum abnormalities	OMIM:620113	MONDO:equivalentTo	neurodevelopmental disorder with growth retardation, dysmorphic facies, and corpus callosum abnormalities		
+MONDO:0859951	neurodevelopmental disorder with speech impairment and with or without seizures	OMIM:620114	MONDO:equivalentTo	neurodevelopmental disorder with speech impairment and with or without seizures		
+MONDO:0859952	developmental and epileptic encephalopathy 108	OMIM:620115	MONDO:equivalentTo	developmental and epileptic encephalopathy 108		MONDO:0100062
+MONDO:0859953	iron overload, susceptibility to	OMIM:620121	MONDO:equivalentTo	iron overload, susceptibility to		
+MONDO:0859954	pseudohypoaldosteronism,  iia ib2, autosomal recessive	OMIM:620125	MONDO:equivalentTo	pseudohypoaldosteronism,  iia ib2, autosomal recessive		
+MONDO:0859955	pseudohypoaldosteronism,  iia ib3, autosomal recessive	OMIM:620126	MONDO:equivalentTo	pseudohypoaldosteronism,  iia ib3, autosomal recessive		
+MONDO:0859956	dyskeratosis congenita, autosomal recessive 8	OMIM:620133	MONDO:equivalentTo	dyskeratosis congenita, autosomal recessive 8		MONDO:0015780
+MONDO:0859957	mitochondrial complex 1 deficiency, nuclear  iia 39	OMIM:620135	MONDO:equivalentTo	mitochondrial complex 1 deficiency, nuclear  iia 39		MONDO:0100223
+MONDO:0859958	mitochondrial complex 3 deficiency, nuclear  iia 11	OMIM:620137	MONDO:equivalentTo	mitochondrial complex 3 deficiency, nuclear  iia 11		MONDO:0020811
+MONDO:0859959	myopathy with myalgia, increased serum creatine kinase, and with or without episodic rhabdomyolysis	OMIM:620138	MONDO:equivalentTo	myopathy with myalgia, increased serum creatine kinase, and with or without episodic rhabdomyolysis		
+MONDO:0859960	combined oxidative phosphorylation deficiency 56	OMIM:620139	MONDO:equivalentTo	combined oxidative phosphorylation deficiency 56		MONDO:0000732
+MONDO:0859961	developmental delay, language impairment, and ocular abnormalities	OMIM:620141	MONDO:equivalentTo	developmental delay, language impairment, and ocular abnormalities		
+MONDO:0859962	developmental and epileptic encephalopathy 109	OMIM:620145	MONDO:equivalentTo	developmental and epileptic encephalopathy 109		MONDO:0100062
+MONDO:0859963	developmental and epileptic encephalopathy 110	OMIM:620149	MONDO:equivalentTo	developmental and epileptic encephalopathy 110		MONDO:0100062
+MONDO:0859964	hypomagnesemia 7, renal, with or without dilated cardiomyopathy	OMIM:620152	MONDO:equivalentTo	hypomagnesemia 7, renal, with or without dilated cardiomyopathy		MONDO:0018100
+MONDO:0859965	mosaic variegated aneuploidy syndrome 4	OMIM:620153	MONDO:equivalentTo	mosaic variegated aneuploidy syndrome 4		MONDO:0000141
+MONDO:0859966	oocyte maturation defect 13	OMIM:620154	MONDO:equivalentTo	oocyte maturation defect 13		
+MONDO:0859967	rabin-pappas syndrome	OMIM:620155	MONDO:equivalentTo	rabin-pappas syndrome		
+MONDO:0859968	cortical dysplasia, complex, with other brain malformations 11	OMIM:620156	MONDO:equivalentTo	cortical dysplasia, complex, with other brain malformations 11		MONDO:0000904
+MONDO:0859969	intellectual developmental disorder, autosomal dominant 70	OMIM:620157	MONDO:equivalentTo	intellectual developmental disorder, autosomal dominant 70		MONDO:0100172
+MONDO:0859970	spinocerebellar ataxia 50	OMIM:620158	MONDO:equivalentTo	spinocerebellar ataxia 50		MONDO:0020380
+MONDO:0859971	muscular dystrophy, congenital, with or without seizures	OMIM:620166	MONDO:equivalentTo	muscular dystrophy, congenital, with or without seizures		
+MONDO:0859972	combined oxidative phosphorylation deficiency 57	OMIM:620167	MONDO:equivalentTo	combined oxidative phosphorylation deficiency 57		MONDO:0000732
+MONDO:0859973	spermatogenic failure 78	OMIM:620170	MONDO:equivalentTo	spermatogenic failure 78		MONDO:0004983
+MONDO:0859974	tooth agenesis, selective, 10	OMIM:620173	MONDO:equivalentTo	tooth agenesis, selective, 10		MONDO:0005486
+MONDO:0859975	spinocerebellar ataxia 27b, late-onset	OMIM:620174	MONDO:equivalentTo	spinocerebellar ataxia 27b, late-onset		MONDO:0020380
+MONDO:0859976	hypotrichosis 15	OMIM:620177	MONDO:equivalentTo	hypotrichosis 15		MONDO:0003037
+MONDO:0859977	microcephaly 30, primary, autosomal recessive	OMIM:620183	MONDO:equivalentTo	microcephaly 30, primary, autosomal recessive		MONDO:0016660
+MONDO:0859978	branchial arch abnormalities, choanal atresia, athelia, hearing loss, and hypothyroidism syndrome	OMIM:620186	MONDO:equivalentTo	branchial arch abnormalities, choanal atresia, athelia, hearing loss, and hypothyroidism syndrome		
+MONDO:0859979	mosaic variegated aneuploidy syndrome 7 with inflammation and tumor predisposition	OMIM:620189	MONDO:equivalentTo	mosaic variegated aneuploidy syndrome 7 with inflammation and tumor predisposition		MONDO:0000141
+MONDO:0859980	neurodevelopmental disorder with hypotonia, dysmorphic facies, and skin abnormalities	OMIM:620191	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia, dysmorphic facies, and skin abnormalities		
+MONDO:0859981	neurodevelopmental disorder with poor growth, large ears, and dysmorphic facies	OMIM:620194	MONDO:equivalentTo	neurodevelopmental disorder with poor growth, large ears, and dysmorphic facies		
+MONDO:0859982	obesity and hypopigmentation	OMIM:620195	MONDO:equivalentTo	obesity and hypopigmentation		
+MONDO:0859983	spermatogenic failure 79	OMIM:620196	MONDO:equivalentTo	spermatogenic failure 79		MONDO:0004983
+MONDO:0859984	ciliary dyskinesia, primary, 49, without situs inversus	OMIM:620197	MONDO:equivalentTo	ciliary dyskinesia, primary, 49, without situs inversus		MONDO:0016575
+MONDO:0859985	thyroid hormone metabolism, abnormal, 3	OMIM:620198	MONDO:equivalentTo	thyroid hormone metabolism, abnormal, 3		MONDO:0031432
+MONDO:0859986	inflammatory poikiloderma with hair abnormalities and acral keratoses	OMIM:620199	MONDO:equivalentTo	inflammatory poikiloderma with hair abnormalities and acral keratoses		
+MONDO:0859987	congenital disorder of glycosylation,  iia iiy	OMIM:620200	MONDO:equivalentTo	congenital disorder of glycosylation,  iia iiy		MONDO:0005501
+MONDO:0859988	congenital disorder of glycosylation,  iia iiz	OMIM:620201	MONDO:equivalentTo	congenital disorder of glycosylation,  iia iiz		MONDO:0005501
+MONDO:0859989	cardiomyopathy, dilated, 2h	OMIM:620203	MONDO:equivalentTo	cardiomyopathy, dilated, 2h		MONDO:0016333
+MONDO:0859990	spinocerebellar ataxia, autosomal recessive 33	OMIM:620208	MONDO:equivalentTo	spinocerebellar ataxia, autosomal recessive 33		MONDO:0015244
+MONDO:0859991	neurodevelopmental disorder with dysmorphic facies and ischiopubic hypoplasia	OMIM:620210	MONDO:equivalentTo	neurodevelopmental disorder with dysmorphic facies and ischiopubic hypoplasia		
+MONDO:0859992	hyperinsulinemic hypoglycemia, familial, 8	OMIM:620211	MONDO:equivalentTo	hyperinsulinemic hypoglycemia, familial, 8		MONDO:0005803
+MONDO:0859993	spastic paraplegia 79a, autosomal dominant, with ataxia	OMIM:620221	MONDO:equivalentTo	spastic paraplegia 79a, autosomal dominant, with ataxia		MONDO:0019064
+MONDO:0859994	spermatogenic failure 80	OMIM:620222	MONDO:equivalentTo	spermatogenic failure 80		MONDO:0004983
+MONDO:0859995	neurodevelopmental disorder with hypotonia, dysmorphic facies, and skeletal anomalies, with or without seizures	OMIM:620224	MONDO:equivalentTo	neurodevelopmental disorder with hypotonia, dysmorphic facies, and skeletal anomalies, with or without seizures		
+MONDO:0859996	deafness, autosomal dominant 85	OMIM:620227	MONDO:equivalentTo	deafness, autosomal dominant 85		MONDO:0019587
+MONDO:0859997	retinitis pigmentosa 96	OMIM:620228	MONDO:equivalentTo	retinitis pigmentosa 96		MONDO:0019200
+MONDO:0859998	short qt syndrome 7	OMIM:620231	MONDO:equivalentTo	short qt syndrome 7		
+MONDO:0859999	joint contractures, osteochondromas, and b-cell lymphoma	OMIM:620232	MONDO:equivalentTo	joint contractures, osteochondromas, and b-cell lymphoma		
+MONDO:0860000	respiratory infections, recurrent, and failure to thrive with or without diarrhea	OMIM:620233	MONDO:equivalentTo	respiratory infections, recurrent, and failure to thrive with or without diarrhea		
+MONDO:0860001	rhabdomyolysis, susceptibility to, 1	OMIM:620235	MONDO:equivalentTo	rhabdomyolysis, susceptibility to, 1		
+MONDO:0860002	cardiomyopathy, familial hypertrophic, 29, with polyglucosan bodies	OMIM:620236	MONDO:equivalentTo	cardiomyopathy, familial hypertrophic, 29, with polyglucosan bodies		MONDO:0024573
+MONDO:0860003	intellectual developmental disorder, autosomal recessive 78	OMIM:620237	MONDO:equivalentTo	intellectual developmental disorder, autosomal recessive 78		MONDO:0019502
+MONDO:0860004	deafness, autosomal recessive 120	OMIM:620238	MONDO:equivalentTo	deafness, autosomal recessive 120		MONDO:0019588
+MONDO:0860005	developmental delay with hypotonia, myopathy, and brain abnormalities	OMIM:620240	MONDO:equivalentTo	developmental delay with hypotonia, myopathy, and brain abnormalities		
+MONDO:0860006	hydrocephalus, congenital, 5, susceptibility to	OMIM:620241	MONDO:equivalentTo	hydrocephalus, congenital, 5, susceptibility to		MONDO:0016349
+MONDO:0860007	neurodevelopmental disorder with poor growth and behavioral abnormalities	OMIM:620242	MONDO:equivalentTo	neurodevelopmental disorder with poor growth and behavioral abnormalities		
+MONDO:0860008	leukodystrophy, hypomyelinating, 25	OMIM:620243	MONDO:equivalentTo	leukodystrophy, hypomyelinating, 25		MONDO:0019046
+MONDO:0860009	lymphatic malformation 13	OMIM:620244	MONDO:equivalentTo	lymphatic malformation 13		MONDO:0019313
+MONDO:0860010	episodic kinesigenic dyskinesia 3	OMIM:620245	MONDO:equivalentTo	episodic kinesigenic dyskinesia 3		MONDO:0044202|MONDO:0044807
+MONDO:0860011	cardiomyopathy, dilated, 1oo	OMIM:620247	MONDO:equivalentTo	cardiomyopathy, dilated, 1oo		MONDO:0016333
+MONDO:0860012	neurodevelopmental disorder with seizures, spasticity, and complete or partial agenesis of the corpus callosum	OMIM:620250	MONDO:equivalentTo	neurodevelopmental disorder with seizures, spasticity, and complete or partial agenesis of the corpus callosum		
+MONDO:0860013	cataract 50 with or without glaucoma	OMIM:620253	MONDO:equivalentTo	cataract 50 with or without glaucoma		MONDO:0005129
+MONDO:0860014	leukodystrophy, hypomyelinating, 26, with chondrodysplasia	OMIM:620269	MONDO:equivalentTo	leukodystrophy, hypomyelinating, 26, with chondrodysplasia		MONDO:0019046
+MONDO:0860015	neurodevelopmental disorder with absent speech and movement and behavioral abnormalities	OMIM:620270	MONDO:equivalentTo	neurodevelopmental disorder with absent speech and movement and behavioral abnormalities		
+MONDO:0860016	mitochondrial complex 4 deficiency, nuclear  iia 23	OMIM:620275	MONDO:equivalentTo	mitochondrial complex 4 deficiency, nuclear  iia 23		MONDO:0033885
+MONDO:0860017	oocyte maturation defect 14	OMIM:620276	MONDO:equivalentTo	oocyte maturation defect 14		MONDO:0014769
+MONDO:0860018	spermatogenic failure 81	OMIM:620277	MONDO:equivalentTo	spermatogenic failure 81		MONDO:0004983
+MONDO:0860019	deafness, autosomal dominant 86	OMIM:620280	MONDO:equivalentTo	deafness, autosomal dominant 86		MONDO:0019587
+MONDO:0860020	deafness, autosomal dominant 87	OMIM:620281	MONDO:equivalentTo	deafness, autosomal dominant 87		MONDO:0019587
+MONDO:0860021	immunodeficiency 109 with lymphoproliferation	OMIM:620282	MONDO:equivalentTo	immunodeficiency 109 with lymphoproliferation		MONDO:0021094
+MONDO:0860022	deafness, autosomal dominant 88	OMIM:620283	MONDO:equivalentTo	deafness, autosomal dominant 88		MONDO:0019587
+MONDO:0860023	deafness, autosomal dominant 89	OMIM:620284	MONDO:equivalentTo	deafness, autosomal dominant 89		MONDO:0019587
+MONDO:0860024	amyotrophic lateral sclerosis 27, juvenile	OMIM:620285	MONDO:equivalentTo	amyotrophic lateral sclerosis 27, juvenile		
+MONDO:0860025	myopathy, sarcoplasmic body	OMIM:620286	MONDO:equivalentTo	myopathy, sarcoplasmic body		
+MONDO:0860026	neurodevelopmental disorder with language delay and behavioral abnormalities, with or without seizures	OMIM:620292	MONDO:equivalentTo	neurodevelopmental disorder with language delay and behavioral abnormalities, with or without seizures		
+MONDO:0860027	congenital heart defects, multiple types, 9	OMIM:620294	MONDO:equivalentTo	congenital heart defects, multiple types, 9		
+MONDO:0860028	myopathy, congenital (see also nemaline myopathy ({ps161800}), myofibrillar myopathy ({ps601419}), and centronuclear myopathy ({ps160150})	OMIMPS:117000	MONDO:equivalentTo	Myopathy, congenital (see also nemaline myopathy ({PS161800}), myofibrillar myopathy ({PS601419}), and centronuclear myopathy ({PS160150})		
+MONDO:0860029	ichthyosis hystrix	OMIMPS:146590	MONDO:equivalentTo	Ichthyosis hystrix		
+MONDO:0860030	lacrimoauriculodentodigital syndrome	OMIMPS:149730	MONDO:equivalentTo	Lacrimoauriculodentodigital syndrome		
+MONDO:0860031	craniofacial dysmorphism, skeletal anomalies, and impaired intellectual development syndrome	OMIMPS:213980	MONDO:equivalentTo	Craniofacial dysmorphism, skeletal anomalies, and impaired intellectual development syndrome		
+MONDO:0860032	epidermodysplasia verruciformis, susceptibility to	OMIMPS:226400	MONDO:equivalentTo	Epidermodysplasia verruciformis, susceptibility to		
+MONDO:0860033	glycogen storage disease	OMIMPS:232200	MONDO:equivalentTo	Glycogen storage disease		
+MONDO:0860034	carey-fineman-ziter syndrome	OMIMPS:254940	MONDO:equivalentTo	Carey-Fineman-Ziter syndrome		
+MONDO:0860035	epilepsy, x-linked, with or without impaired intellectual development and dysmorphic features	OMIMPS:300491	MONDO:equivalentTo	Epilepsy, X-linked, with or without impaired intellectual development and dysmorphic features		
+MONDO:0860036	ichthyosis, annular epidermolytic	OMIMPS:607602	MONDO:equivalentTo	Ichthyosis, annular epidermolytic		
+MONDO:0860037	developmental delay with short stature, dysmorphic facial features, and sparse hair	OMIMPS:616901	MONDO:equivalentTo	Developmental delay with short stature, dysmorphic facial features, and sparse hair		
+MONDO:0860038	atelis syndrome	OMIMPS:620184	MONDO:equivalentTo	Atelis syndrome		


### PR DESCRIPTION
Bugfix: OMIMPS children
- Bugfix: Where OMIMPS children weren't present
- Bugfix: Slurp cache was being used. This is what caused the above bug.
- Bugfix: When robot is not found in path, it will try a specific path. This won't be a bugfix for most people. This is more of an issue with Joe's specific setup.
- Update: Now removes cached files if --use-cache is False. There are times where it could be good to retain an old cache, but opting to do this for the following bugfix reason.
- Bugfix: Delete files from cache if --use-cache is False. This is a quick way to fix potential edge case where running the a jinja_sparql() encounters an issue when running a subprocess that does not result in an error, but also does not result in successful output being written. In that case, previously cached results were erroneously being re-read.