### PR TITLE
Bugfix: Migrate: `FileNotFoundError`

### DIFF
--- a/src/scripts/utils.py
+++ b/src/scripts/utils.py
@@ -396,9 +396,8 @@ def jinja_sparql(
     # - If return from cache, empties existing cache before running
     os.makedirs(results_dirpath, exist_ok=True)
     if not (os.path.exists(results_path) and use_cache):
-        os.remove(instantiated_query_path)
-        os.remove(command_str)
-        os.remove(results_path)
+        if os.path.exists(results_path):
+            os.remove(results_path)
         with open(instantiated_query_path, 'w') as f:
             f.write(instantiated_str)
         with open(command_save_path, 'w') as f:


### PR DESCRIPTION
Bugfix: Migrate: Tried to remove files that might not have been there, resulting in FileNotFoundError. Also 2 out of 3 of the file removals seemed redundant, so only removing 1 of them now.