### PR TITLE
Bugfix: Bug `KeyError: 'mondo_id'` in `migrate.py`

### DIFF
--- a/src/scripts/migrate.py
+++ b/src/scripts/migrate.py
@@ -128,8 +128,9 @@ def slurp(
 
     # Sort, add robot row, save and return
     result = pd.DataFrame(terms_to_slurp)
-    result = result.sort_values(
-        ['mondo_id', 'mondo_label', 'xref', 'xref_source', 'original_label', 'definition', 'parents'])
+    if len(result) > 0:
+        result = result.sort_values(
+            ['mondo_id', 'mondo_label', 'xref', 'xref_source', 'original_label', 'definition', 'parents'])
     result = pd.concat([pd.DataFrame([ROBOT_TEMPLATE_HEADER]), result])
     result.to_csv(outpath, sep='\t', index=False)
     return result


### PR DESCRIPTION
- Bugfix: Slurp/Migrate: Fixed issue where when there were no results it would try to sort an empty data frame and result in KeyError on the first column (i.e. mondo_id).