### PR TITLE
Bugfix: Slurp: `max() arg is an empty sequence`

### DIFF
--- a/src/scripts/migrate.py
+++ b/src/scripts/migrate.py
@@ -74,7 +74,7 @@ def slurp(
     for f in slurp_files:
         slurp_df = pd.read_csv(os.path.join(slurp_dir_path, f), sep='\t')
         slurp_ids = [int(x.split(':')[1]) for x in list(slurp_df['mondo_id'])[1:]]
-        next_mondo_id = max(next_mondo_id, max(slurp_ids) + 1)
+        next_mondo_id = max(next_mondo_id, max(slurp_ids) + 1) if slurp_ids else next_mondo_id
 
     # Get map of native IDs to existing slurp mondo IDs
     slurp_id_map: Dict[str, str] = {}


### PR DESCRIPTION
- Bugfix: Fixed issue where during slurp we were collecting any assigned mondo IDs already present in the slurp files so as not to assign duplicate IDs. However, during this process, if a slurp file was empty, this was causing an error.