### PR TITLE
Subprocess output

### DIFF
--- a/src/analysis/problematic_exclusions.py
+++ b/src/analysis/problematic_exclusions.py
@@ -133,7 +133,7 @@ def populate_labels(
             f.write(instantiated_str)
         with open(command_save_path, 'w') as f:
             f.write(command_str)
-        subprocess.run(command_str.split())
+        subprocess.run(command_str.split(), capture_output=True, text=True)
 
     # Read results and return
     try:

--- a/src/scripts/ordo_mapping_annotations/report_mapping_annotations.py
+++ b/src/scripts/ordo_mapping_annotations/report_mapping_annotations.py
@@ -63,7 +63,7 @@ def sparql_file_query__via_robot(onto_path: str, query_path: str, use_cache=Fals
         if not os.path.exists(results_path):
             with open(command_save_path, 'w') as f:
                 f.write(command_str)
-        subprocess.run(command_str.split())
+        subprocess.run(command_str.split(), capture_output=True, text=True)
 
     # Read results and return
     try:

--- a/src/scripts/utils.py
+++ b/src/scripts/utils.py
@@ -404,12 +404,12 @@ def jinja_sparql(
         with open(command_save_path, 'w') as f:
             f.write(command_str)
         try:
-            result = subprocess.run(command_str.split())
+            result = subprocess.run(command_str.split(), capture_output=True, text=True)
         except FileNotFoundError as e:
             if 'robot' in str(e):
                 # joeflack4 2023/04/25: Suddenly my PATH is wrong. Could be virtualenvwrapper+PyCharm issue.
                 command_str = command_str.replace('robot query', '/usr/local/bin/robot query')
-                result = subprocess.run(command_str.split())
+                result = subprocess.run(command_str.split(), capture_output=True, text=True)
             else:
                 raise e
         stderr, stdout = result.stderr, result.stdout


### PR DESCRIPTION
- Bugfix: On Python 3.7+, additional flags needed to be passed to subprocess.run() in order to capture output, which some of our code was depending on in order to check if any errors occurred, etc.