### PR TITLE
SemanticSQL `.db` goal updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ src/ontology/imports/*.owl
 !src/ontology/imports/ro_import.owl
 src/ontology/imports/*.json
 src/ontology/imports/*_terms_combined.txt
-src/ontology/mondo-ingest.db
 
 src/ontology/components/*
 


### PR DESCRIPTION
## Updates
    Artefact & makefile updates
    - Rename: mondo-ingest.db --> merged.db: It was coming from merged.owl, and this was causing a conflict, since mondo-ingest.db (from mondo-ingest.owl) is needed separately.

    Makefile updates
    - Update: %.db: Replaces all other *.db goals, unless they have a specific goal that overrides.
    - Add: tmp/mondo-ingest.db

## Context
- https://github.com/monarch-initiative/mondo-ingest/pull/363#discussion_r1396484410