### PR TITLE
Bug in `match-mondo-sources-all-lexical.py`

### DIFF
--- a/python-requirements-apple-silicon.txt
+++ b/python-requirements-apple-silicon.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
 class-resolver==0.4.2
 click==8.1.7
 colorama==0.4.6
-curies==0.7.4
+curies==0.7.6
 Deprecated==1.2.14
 deprecation==2.1.0
 distlib==0.3.7

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -22,7 +22,7 @@ class-resolver==0.4.2
 click==8.1.7
 colorama==0.4.6
 commonmark==0.9.1
-curies==0.6.4
+curies==0.7.6
 decorator==5.1.1
 Deprecated==1.2.13
 deprecation==2.1.0

--- a/src/ontology/config/prefixes.csv
+++ b/src/ontology/config/prefixes.csv
@@ -3,7 +3,7 @@ rdf,http://www.w3.org/1999/02/22-rdf-syntax-ns#
 rdfs,http://www.w3.org/2000/01/rdf-schema#
 xsd,http://www.w3.org/2001/XMLSchema#
 owl,http://www.w3.org/2002/07/owl#
-oio,http://www.geneontology.org/formats/oboInOwl#
+oboInOwl,http://www.geneontology.org/formats/oboInOwl#
 dce,http://purl.org/dc/elements/1.1/
 dct,http://purl.org/dc/terms/
 foaf,http://xmlns.com/foaf/0.1/

--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -34,7 +34,7 @@ curie_map:
   semapv: https://w3id.org/semapv/vocab/
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   sssom: https://w3id.org/sssom/
-  oio: http://www.geneontology.org/formats/oboInOwl#
+#  oio: http://www.geneontology.org/formats/oboInOwl#
   GTR: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/GTR/"
   NCI: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/NCI/"
   NIFSTD: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/NIFSTD/"


### PR DESCRIPTION
## Updates
Bugfixes: match-mondo-sources-all-lexical.py
- Bugfix: AttributeError: 'tuple' object has no attribute 'pop': wrong datatype for metadata was being passed to lexical_index_to_sssom()
- Bugfix: Several other bugs in mondo-ingest, and upgrading OAK/sssom-py/curies to fix other bugs related to prefix maps.
- Update: mondo.sssom.config.yml: Commented out duplicate prefix 'oio'
- Update: prefixes.csv: Removed duplicate prefix oio
- Update: Python requirements: Upgraded curies for bugfix involving get_prefixes(include_synonyms)
- Update: Not bugfixes, but did some codestyle fixes: (i) converted regular comments to docstring, (ii) added missing docs
tring, (iii) renamed built-in 'input' param

## Sub-tasks
- [x] 1. Determine if OAK changes needed or not & PR if so _(not needed)_
- [x] 2. Fulfill all requests / tasks in `sssom-py` PR: https://github.com/mapping-commons/sssom-py/pull/485
  - [x] Remove passing of non-bijective map into `sssom-py` if possible
  - [x] Upgrade `sssom-py` and `curies` and use those recent changes instead of my PR changes, if needed _(wasn't necessary for this PR but upgraded `curies` anyway. may need in near future)_
- [x] 3. If root problem needs to be addressed (`oio` and `oboInOwl` both in Mondo), make PR in `mondo` repo too _(doesn't seems so. seems to be related to `oio` in `config/prefixes.csv`)_
- [x] 4. Fix original bug in issue: `AttributeError: 'tuple' object has no attribute 'pop'`
- [x] 5. Add EPM to `mondo-ingest`
- [x] 6. Remove `oio` from `mondo.sssom.config.yaml` `curie_map` and `prefixes.csv`

## Related
- https://github.com/mapping-commons/sssom-py/pull/485
  - Has necessary bugfix to `clean_prefix_map()` (`.get_prefix(include_synonyms=True)`)
- https://github.com/INCATools/ontology-access-kit/pull/697
  - This one is not necessary to merge in order to fix anything but was inspired by what I was working on here.
- https://github.com/INCATools/ontology-access-kit/issues/698
  - We can probably avoid addressing this issue by changing our `oio` to `oboInOwl` in part of our pipeline.

---

@souzadevinicius FYI. Harshad is out ATM so I'm helping out with a bug that appeared here, but it opened a can of worms, involving conflicting prefixes that are causing trouble when `mondo-ingest` interacts with SSSOM and OAK. And we've been decided how to fix this, involving using extended prefix maps instead of plain, flat, bijective prefix maps (key: val), etc.