### PR TITLE
Add `extended_prefix_map`

### DIFF
--- a/src/ontology/metadata/mondo.sssom.config.yml
+++ b/src/ontology/metadata/mondo.sssom.config.yml
@@ -75,6 +75,274 @@ curie_map:
   GC_ID: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/GC_ID/"
   SNOMEDCT_2010_1_31: "http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/SNOMEDCT_2010_1_31/"
 
+extended_prefix_map:
+  - prefix: MONDO
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/MONDO_
+    uri_prefix_synonyms: []
+  - prefix: UMLS
+    prefix_synonyms: []
+    uri_prefix: http://linkedlifedata.com/resource/umls/id/
+    uri_prefix_synonyms: []
+  - prefix: NCIT
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/NCIT_
+    uri_prefix_synonyms: []
+  - prefix: DOID
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/DOID_
+    uri_prefix_synonyms: []
+  - prefix: EFO
+    prefix_synonyms: []
+    uri_prefix: http://www.ebi.ac.uk/efo/EFO_
+    uri_prefix_synonyms: []
+  - prefix: HGNC
+    prefix_synonyms: []
+    uri_prefix: http://identifiers.org/hgnc/
+    uri_prefix_synonyms:
+      - 'https://identifiers.org/hgnc:'
+      - 'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:'
+  - prefix: HGNC_symbol
+    prefix_synonyms: []
+    uri_prefix: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/
+    uri_prefix_synonyms: []
+  - prefix: HP
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/HP_
+    uri_prefix_synonyms: []
+  - prefix: SCTID
+    prefix_synonyms: []
+    uri_prefix: http://identifiers.org/snomedct/
+    uri_prefix_synonyms:
+      = http://snomed.info/id/
+  - prefix: OMIM
+    prefix_synonyms: []
+    uri_prefix: https://omim.org/entry/
+    uri_prefix_synonyms:
+      - http://identifiers.org/omim/
+      - http://purl.obolibrary.org/obo/OMIM_
+      - http://omim.org/entry/
+  - prefix: MESH
+    prefix_synonyms: []
+    uri_prefix: http://identifiers.org/mesh/
+    uri_prefix_synonyms: []
+  - prefix: Orphanet
+    prefix_synonyms: []
+    uri_prefix: http://www.orpha.net/ORDO/Orphanet_
+    uri_prefix_synonyms:
+      - https://www.orpha.net/ORDO/Orphanet_
+      - http://purl.obolibrary.org/obo/Orphanet_
+  - prefix: oboInOwl
+    prefix_synonyms:
+    - oio
+    uri_prefix: http://www.geneontology.org/formats/oboInOwl#
+    uri_prefix_synonyms: []
+  - prefix: NCBITaxon
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/NCBITaxon_
+    uri_prefix_synonyms: []
+  - prefix: skos
+    prefix_synonyms: []
+    uri_prefix: http://www.w3.org/2004/02/skos/core#
+    uri_prefix_synonyms: []
+  - prefix: ICD10CM
+    prefix_synonyms: []
+    uri_prefix: http://purl.bioontology.org/ontology/ICD10CM/
+    uri_prefix_synonyms:
+      -  https://icd.codes/icd10cm/
+  - prefix: ICD10WHO
+    prefix_synonyms: []
+    uri_prefix: https://icd.who.int/browse10/2019/en#/
+    uri_prefix_synonyms:
+      - http://apps.who.int/classifications/icd10/browse/2010/en#/
+  - prefix: OMIMPS
+    prefix_synonyms: []
+    uri_prefix: https://omim.org/phenotypicSeries/PS
+    uri_prefix_synonyms: []
+  - prefix: MEDGEN
+    prefix_synonyms: []
+    uri_prefix: http://identifiers.org/medgen/
+    uri_prefix_synonyms: []
+  - prefix: MedDRA
+    prefix_synonyms: []
+    uri_prefix: http://identifiers.org/meddra/
+    uri_prefix_synonyms: []
+  - prefix: rdfs
+    prefix_synonyms: []
+    uri_prefix: http://www.w3.org/2000/01/rdf-schema#
+    uri_prefix_synonyms: []
+  - prefix: owl
+    prefix_synonyms: []
+    uri_prefix: http://www.w3.org/2002/07/owl#
+    uri_prefix_synonyms: []
+  - prefix: semapv
+    prefix_synonyms: []
+    uri_prefix: https://w3id.org/semapv/vocab/
+    uri_prefix_synonyms: []
+  - prefix: rdf
+    prefix_synonyms: []
+    uri_prefix: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+    uri_prefix_synonyms: []
+  - prefix: sssom
+    prefix_synonyms: []
+    uri_prefix: https://w3id.org/sssom/
+    uri_prefix_synonyms: []
+  - prefix: GTR
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/GTR/
+    uri_prefix_synonyms: []
+  - prefix: NCI
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/NCI/
+    uri_prefix_synonyms: []
+  - prefix: NIFSTD
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/NIFSTD/
+    uri_prefix_synonyms: []
+  - prefix: PO_GIT
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/PO_GIT/
+    uri_prefix_synonyms: []
+  - prefix: CALOHA
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/CALOHA/
+    uri_prefix_synonyms: []
+  - prefix: Reactome
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/Reactome/
+    uri_prefix_synonyms: []
+  - prefix: MTH
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/MTH/
+    uri_prefix_synonyms: []
+  - prefix: IMDRF
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/IMDRF/
+    uri_prefix_synonyms: []
+  - prefix: LOINC
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/LOINC/
+    uri_prefix_synonyms: []
+  - prefix: MEDDRA
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/MEDDRA/
+    uri_prefix_synonyms: []
+  - prefix: ncithesaurus
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ncithesaurus/
+    uri_prefix_synonyms: []
+  - prefix: COHD
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/COHD/
+    uri_prefix_synonyms: []
+  - prefix: ONCOTREE
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ONCOTREE/
+    uri_prefix_synonyms: []
+  - prefix: ICD9
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICD9/
+    uri_prefix_synonyms: []
+  - prefix: NDFRT
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/NDFRT/
+    uri_prefix_synonyms: []
+  - prefix: ICD9CM
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICD9CM/
+    uri_prefix_synonyms: []
+  - prefix: SUBSET_SIREN
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/SUBSET_SIREN/
+    uri_prefix_synonyms: []
+  - prefix: ICDO
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICDO/
+    uri_prefix_synonyms: []
+  - prefix: Wikidata
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/Wikidata/
+    uri_prefix_synonyms: []
+  - prefix: IEDB
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/IEDB/
+    uri_prefix_synonyms: []
+  - prefix: PMID
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/PMID/
+    uri_prefix_synonyms: []
+  - prefix: KEGG
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/KEGG/
+    uri_prefix_synonyms: []
+  - prefix: ICD11
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICD11/
+    uri_prefix_synonyms: []
+  - prefix: DECIPHER
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/DECIPHER/
+    uri_prefix_synonyms: []
+  - prefix: CSP
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/CSP/
+    uri_prefix_synonyms: []
+  - prefix: Wikipedia
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/Wikipedia/
+    uri_prefix_synonyms: []
+  - prefix: Fyler
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/Fyler/
+    uri_prefix_synonyms: []
+  - prefix: EPCC
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/EPCC/
+    uri_prefix_synonyms: []
+  - prefix: UMLS_CUI
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/UMLS_CUI/
+    uri_prefix_synonyms: []
+  - prefix: KUPO
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/KUPO/
+    uri_prefix_synonyms: []
+  - prefix: OMOP
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/OMOP/
+    uri_prefix_synonyms: []
+  - prefix: ICD10
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICD10/
+    uri_prefix_synonyms: []
+  - prefix: ICD10EXP
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/ICD10EXP/
+    uri_prefix_synonyms: []
+  - prefix: DERMO
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/DERMO/
+    uri_prefix_synonyms: []
+  - prefix: GARD
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/GARD/
+    uri_prefix_synonyms: []
+  - prefix: SNOMEDCT_US
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/SNOMEDCT_US/
+    uri_prefix_synonyms: []
+  - prefix: MSH
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/MSH/
+    uri_prefix_synonyms: []
+  - prefix: GC_ID
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/GC_ID/
+    uri_prefix_synonyms: []
+  - prefix: SNOMEDCT_2010_1_31
+    prefix_synonyms: []
+    uri_prefix: http://purl.obolibrary.org/obo/mondo/mappings/unknown_prefix/SNOMEDCT_2010_1_31/
+    uri_prefix_synonyms: []
 
 subject_prefixes:
   - MONDO


### PR DESCRIPTION
## Changes
- Add: `extended_prefix_map` to `mondo.sssom.config.yml`

---

@souzadevinicius FYI. We're moving from plain, flat, bijective prefix map to "[extended prefix maps](https://bioregistry.readthedocs.io/en/v0.8.6/api/bioregistry.get_extended_prefix_map.html)" which capture such things as prefix and URI prefix synonyms.