### PR TITLE
Bug: Sync subclass: ancestor inconsistencies

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -345,13 +345,17 @@ documentation: j2 $(ALL_DOCS) unmapped-terms-docs mapped-deprecated-terms-docs s
 build-mondo-ingest:
 	$(MAKE) refresh-imports exclusions-all slurp-all mappings matches \
 		mapped-deprecated-terms mapping-progress-report \
-		recreate-unmapped-components sync documentation
-	$(MAKE) prepare_release
+		recreate-unmapped-components sync documentation \
+		prepare_release
 	echo "Mondo Ingest has been fully completed"
 
 .PHONY: build-mondo-ingest-no-imports
 build-mondo-ingest-no-imports:
-	$(MAKE_FAST) build-mondo-ingest
+	$(MAKE_FAST) exclusions-all slurp-all mappings matches \
+		mapped-deprecated-terms mapping-progress-report \
+		recreate-unmapped-components sync documentation \
+		prepare_release
+	echo "Mondo Ingest has been fully completed"
 
 DEPLOY_ASSETS_MONDO_INGEST=$(OTHER_SRC) $(ALL_MAPPINGS) ../../mondo-ingest.owl ../../mondo-ingest.obo
 

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -32,7 +32,7 @@ dependencies:
 ### General ########################
 ####################################
 %.db: %.owl
-	@rm $*.db
+	@rm -f $*.db
 	@rm -f .template.db
 	@rm -f .template.db.tmp
 	@rm -f $*-relation-graph.tsv.gz

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -437,7 +437,7 @@ tmp/merged.owl: tmp/mondo.owl mondo-ingest.owl tmp/mondo.sssom.ttl
 $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv: $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py tmp/merged.db $(MAPPINGSDIR)/rejected-mappings.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical-2.sssom.tsv
-	pip install bioregistry
+	$(MAKE) pip-bioregistry
 	python $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py run tmp/merged.db \
 		-c metadata/mondo.sssom.config.yml \
 		-r config/mondo-match-rules.yaml \

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -437,6 +437,7 @@ tmp/merged.owl: tmp/mondo.owl mondo-ingest.owl tmp/mondo.sssom.ttl
 $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv: $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py tmp/merged.db $(MAPPINGSDIR)/rejected-mappings.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical-2.sssom.tsv
+	pip install bioregistry
 	python $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py run tmp/merged.db \
 		-c metadata/mondo.sssom.config.yml \
 		-r config/mondo-match-rules.yaml \

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -499,5 +499,5 @@ def run_defaults(use_cache=True):  # todo: #remove-temp-defaults
 
 
 if __name__ == '__main__':
-    # cli()
-    run_defaults()  # TODO temp
+    cli()
+    #run_defaults()  # TODO temp

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -309,7 +309,8 @@ def sync_subclassof(
     missing_ancestor_rels = rels_indirect_mondo_mondo.union(rels_direct_mondo_mondo).difference(ancestors_mondo_mondo)
     if missing_ancestor_rels:
         rels_for_printing =  [rel for rel in list(missing_ancestor_rels)[:5]]
-        logging.error(
+        # TODO: temp:
+        raise ValueError(
             'Detected error in consistency of sets of terms gathered from Mondo.\n'
             f'\n 1. Mondo SCR ancestors: {len(ancestors_mondo_mondo)}'
             f'\n 2. Mondo direct SCR relationships: {len(rels_direct_mondo_mondo)}'
@@ -498,4 +499,5 @@ def run_defaults(use_cache=True):  # todo: #remove-temp-defaults
 
 
 if __name__ == '__main__':
-    cli()
+    # cli()
+    run_defaults()  # TODO temp


### PR DESCRIPTION
## Changes
Bugfix sync ancestors
- Bugfix: Fixed bug in .ancestors() results were not consistent with direct + indirect results.

## Status
Not ready for review yet. Still trying to replicate issue. See: [comment](https://github.com/monarch-initiative/mondo-ingest/issues/406#issuecomment-1913801438).

## Addresses
Addresses part of:
- #408