### PR TITLE
`update-repo-wrapper`

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -575,6 +575,20 @@ update-jinja-sparql-queries:
 	python3 $(SCRIPTSDIR)/ordo_mapping_annotations/create_sparql__ordo_replace_annotation_based_mappings.py
 	python3 $(SCRIPTSDIR)/ordo_mapping_annotations/create_sparql__ordo_mapping_annotations_violation.py
 
+# update-repo-wrapper
+UPDATE_REPO_ODK_TAG := latest
+ifdef ODK_TAG
+	UPDATE_REPO_ODK_TAG := $(ODK_TAG)
+endif
+
+.PHONY: update-repo-wrapper
+update-repo-wrapper:
+	@sed -i.bak '/^ODK_TAG=/s/.*/ODK_TAG=${UPDATE_REPO_ODK_TAG}/' run.sh.conf
+	-$(MAKE) update_repo
+	-$(MAKE) update_repo
+	@mv run.sh.conf.bak run.sh.conf
+
+
 #############################
 ########### Help ############
 #############################


### PR DESCRIPTION
resolves #435

## Overview
Convenience command to automate some otherwise manual steps when running `update_repo`. Expected behavior is that it (i) temporarily updates the `ODK_TAG` used, and (ii) runs `update_repo` twice, until a fix for https://github.com/INCATools/ontology-development-kit/issues/989 is in ODK.

## Pre-merge checklist
- [ ] Docs
   - `docs/` have been added/updated **OR**
   - No updates to the docs necessary after careful consideration.
- [x] QC
   - `sh run.sh make build-mondo-ingest` has been run on this branch (after `docker pull obolibrary/odkfull:dev), and no errors occurred **OR**
   -  No functional (code-related) changes to the pipeline are suggested, so no re-run is necessary.
- [x] Account for any new packages
  - Open an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) to request addition. Can also open a PR. Python package changes should occur in [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full), and non-Python packages in [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile).
- [ ] Reviewed
   - Has been sufficiently reviewed by at least one review from a different team member of the Mondo Technical team.

## Changes
- Update: mondo-ingest.Makefile: Added goal 'update-repo-wrapper' to automate some steps required to run 'update_repo'.