### PR TITLE
Bugfix for fresh clone: `tmp/` does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ src/ontology/target/
 
 # src/ontology/tmp/
 src/ontology/tmp/*
+!src/ontology/tmp/.gitkeep
 !src/ontology/tmp/README.md
 
 # src/patterns/


### PR DESCRIPTION
## Overview
Resolves `cannot create tmp/debug.log: Directory nonexistent`. If run-command.sh runs on a fresh clone, it will fail because it tries to append to a debug log, but it can't do that because the directory for that file doesn't exist.

## Pre-merge checklist
- [x] Docs
   - `docs/` have been added/updated **OR**
   - No updates to the docs necessary after careful consideration.
- [x] QC
   - `sh run.sh make build-mondo-ingest` has been run on this branch (after `docker pull obolibrary/odkfull:dev), and no errors occurred **OR**
   -  No functional (code-related) changes to the pipeline are suggested, so no re-run is necessary.
- [x] Account for any new packages
  - Open an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) to request addition. Can also open a PR. Python package changes should occur in [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full), and non-Python packages in [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile).
- [x] Reviewed
   - Has been sufficiently reviewed by at least one review from a different team member of the Mondo Technical team.

## Changes
    Bugfix tmp/ not exist
    If run-command.sh runs on a fresh clone, it will fail because it tries to append to a debug log, but it can't do that because the directory for that file doesn't exist.

--- 

CC @souzadevinicius