### PR TITLE
Bugfix for fresh clone: `tmp/` does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ src/ontology/target/
 
 # src/ontology/tmp/
 src/ontology/tmp/*
+!src/ontology/tmp/.gitkeep
 !src/ontology/tmp/README.md
 
 # src/patterns/


### PR DESCRIPTION
## Overview
If run-command.sh runs on a fresh clone, it will fail because it tries to append to a debug log, but it can't do that because the directory for that file doesn't exist.

## Pre-merge checklist
### Documentation
- Was the documentation added/updated under `docs/`?
   - [ ] Yes
   - [x] No, updates to the docs were not necessary after careful consideration

### QC
- Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after `docker pull obolibrary/odkfull:dev`), and no errors occurred?
   - [ ] Yes
   - [x] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
- Were any new *Python packages* added?
   - [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
   - [x] No
</br>

- Were any other *non-Python packages* added?
   - [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
   - [x] No

### PR Review and Conversations Resolved
- Has the PR been sufficiently reviewed by at least one team member of the Mondo Technical team and all threads resolved?
   - [x] Yes

## Additional info
Related:
- #443