### PR TITLE
Subclass Sync: Self-parentage

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -511,7 +511,14 @@ slurp-all: $(foreach n,$(ALL_COMPONENT_IDS), slurp-$(n))
 sync: sync-subclassof
 
 .PHONY: sync-subclassof
-sync-subclassof: $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv
+sync-subclassof: $(REPORTDIR)/sync-subClassOf.added.self_parentage_issues.tsv
+
+$(REPORTDIR)/sync-subClassOf.added.self_parentage_issues.tsv: tmp/mondo.sssom.tsv
+	rm -f $@
+	$(MAKE) $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv
+	python3 $(SCRIPTSDIR)/sync_subclassof_collate_self_parentage.py \
+	--mondo-mappings-path $(TMPDIR)/mondo.sssom.tsv \
+	--in-outpath $@
 
 # todo: drop this? This is really just an alias here for quality of life, but not used by anything.
 .PHONY: sync-subclassof-%

--- a/src/ontology/reports/sync-subClassOf.added.self_parentage_issues.tsv
+++ b/src/ontology/reports/sync-subClassOf.added.self_parentage_issues.tsv
@@ -1,0 +1,83 @@
+mondo_id	mondo_label	subject_source_id	subject_source_label	object_source_id	object_source_label
+MONDO:0005823	legionellosis	Orphanet:549	Legionnaires disease	Orphanet:600832	Legionella infection
+MONDO:0007800	chromosome 18p deletion syndrome	Orphanet:1598	Monosomy 18p	Orphanet:261974	Partial deletion of the short arm of chromosome 18
+MONDO:0007864	angioosteohypertrophic syndrome	Orphanet:90308	Klippel-Trénaunay syndrome	Orphanet:2346	Angioosteohypertrophic syndrome
+MONDO:0007947	Marfan syndrome	Orphanet:284963	Marfan syndrome type 1	Orphanet:558	Marfan syndrome
+MONDO:0010674	mucopolysaccharidosis type 2	Orphanet:580	Mucopolysaccharidosis type 2	Orphanet:79388	Mucopolysaccharidosis with skin involvement
+MONDO:0011147	chromosome 18q deletion syndrome	Orphanet:1600	Monosomy 18q	Orphanet:262146	Partial deletion of the long arm of chromosome 18
+MONDO:0011669	hypotonia-cystinuria syndrome	Orphanet:163690	Hypotonia-cystinuria syndrome	Orphanet:238517	Hypotonia-cystinuria type 1 syndrome
+MONDO:0015541	hereditary hemophagocytic lymphohistiocytosis	Orphanet:540	Familial hemophagocytic lymphohistiocytosis	Orphanet:158038	Primary hemophagocytic lymphohistiocytosis
+MONDO:0015722	congenital vitamin K-dependent coagulation factors deficiency	Orphanet:98434	Hereditary combined deficiency of vitamin K-dependent clotting factors	Orphanet:169826	Congenital vitamin K-dependent coagulation factors deficiency
+MONDO:0016163	autosomal dominant cerebellar ataxia type II	Orphanet:94147	Spinocerebellar ataxia type 7	Orphanet:208508	Autosomal dominant cerebellar ataxia type II
+MONDO:0016525	familial hyperaldosteronism	Orphanet:235936	Familial hyperaldosteronism	Orphanet:371861	Genetic hyperaldosteronism
+MONDO:0016526	trisomy 9p	Orphanet:236	Trisomy 9p	Orphanet:262767	Partial duplication/triplication of the short arm of chromosome 9
+MONDO:0016620	primary hypertrophic osteoarthropathy	Orphanet:2796	Pachydermoperiostosis	Orphanet:248095	Primary hypertrophic osteoarthropathy
+MONDO:0017287	IgG4-related disease	Orphanet:596448	IgG4-related systemic disease	Orphanet:284264	IgG4-related disease
+MONDO:0017851	erythrokeratodermia variabilis	Orphanet:316	Progressive symmetric erythrokeratodermia	Orphanet:308166	Erythrokeratoderma variabilis progressiva
+MONDO:0017851	erythrokeratodermia variabilis	Orphanet:317	Erythrokeratodermia variabilis	Orphanet:308166	Erythrokeratoderma variabilis progressiva
+MONDO:0018677	visceral heterotaxy	Orphanet:157769	Situs ambiguus	Orphanet:450	Heterotaxia
+MONDO:0018931	mucolipidosis type III, alpha/beta	Orphanet:423461	Mucolipidosis type III alpha/beta	Orphanet:577	Mucolipidosis type III
+MONDO:0019171	familial long QT syndrome	Orphanet:101016	Romano-Ward syndrome	Orphanet:768	Familial long QT syndrome
+MONDO:0000430	mature T-cell and NK-cell non-Hodgkin lymphoma	DOID:0050749	peripheral T-cell lymphoma	DOID:0050743	mature T-cell and NK-cell lymphoma
+MONDO:0001561	pyloric stenosis	DOID:12639	pyloric stenosis	DOID:3122	gastric outlet obstruction
+MONDO:0002008	labyrinthitis	DOID:1468	labyrinthitis	DOID:3930	otitis interna
+MONDO:0002277	arteriosclerosis disorder	DOID:2348	arteriosclerotic cardiovascular disease	DOID:2349	arteriosclerosis
+MONDO:0002412	disorder of glycogen metabolism	DOID:2747	glycogen storage disease	DOID:0050728	glycogen metabolism disorder
+MONDO:0002422	adamantinoma	DOID:2775	long bone adamantinoma	DOID:2776	adamantinoma
+MONDO:0002829	bartholin gland carcinoma	DOID:3999	Bartholin's gland carcinoma	DOID:60003	Bartholin's gland cancer
+MONDO:0003061	benign muscle neoplasm	DOID:2691	myoma	DOID:461	muscle benign neoplasm
+MONDO:0003704	uterine corpus diffuse leiomyomatosis	DOID:5917	uterine corpus diffuse leiomyomatosis	DOID:5916	uterine corpus leiomyomatosis
+MONDO:0003924	adrenal cortex adenoma	DOID:0050891	adrenal cortical adenoma	DOID:656	adrenal adenoma
+MONDO:0003939	muscle tissue disorder	DOID:66	muscle tissue disease	DOID:0080000	muscular disease
+MONDO:0004598	acute cor pulmonale	DOID:8517	acute cor pulmonale	DOID:8514	acute pulmonary heart disease
+MONDO:0004992	cancer	DOID:0050686	organ system cancer	DOID:162	cancer
+MONDO:0004992	cancer	DOID:0050687	cell type cancer	DOID:162	cancer
+MONDO:0005032	follicular thyroid adenoma	DOID:6204	follicular adenoma	DOID:2891	thyroid adenoma
+MONDO:0005165	benign neoplasm	DOID:0060084	cell type benign neoplasm	DOID:0060072	benign neoplasm
+MONDO:0005165	benign neoplasm	DOID:0060085	organ system benign neoplasm	DOID:0060072	benign neoplasm
+MONDO:0005328	eye disorder	DOID:1242	globe disease	DOID:5614	eye disease
+MONDO:0005380	osteonecrosis	DOID:10159	osteonecrosis	DOID:0080008	ischemic bone disease
+MONDO:0005575	colorectal cancer	DOID:9256	colorectal cancer	DOID:5672	large intestine cancer
+MONDO:0006639	adrenal cortex carcinoma	DOID:3948	adrenocortical carcinoma	DOID:660	adrenal cortex cancer
+MONDO:0006639	adrenal cortex carcinoma	DOID:3959	adrenal cortical adenocarcinoma	DOID:3948	adrenocortical carcinoma
+MONDO:0006676	beriberi	DOID:13725	beriberi	DOID:0070313	thiamine deficiency disease
+MONDO:0006733	dry eye syndrome	DOID:12895	keratoconjunctivitis sicca	DOID:10140	dry eye syndrome
+MONDO:0006962	sebaceous adenocarcinoma	DOID:4839	sebaceous adenocarcinoma	DOID:4840	sebaceous carcinoma
+MONDO:0007187	nevoid basal cell carcinoma syndrome	DOID:0070365	nevoid basal cell carcinoma syndrome 1	DOID:2512	nevoid basal cell carcinoma syndrome
+MONDO:0007256	hepatocellular carcinoma	DOID:684	hepatocellular carcinoma	DOID:686	liver carcinoma
+MONDO:0008048	autosomal dominant centronuclear myopathy	DOID:0111223	centronuclear myopathy 1	DOID:0111217	autosomal dominant centronuclear myopathy
+MONDO:0008433	small cell lung carcinoma	DOID:5411	lung oat cell carcinoma	DOID:5409	lung small cell carcinoma
+MONDO:0008675	Freeman-Sheldon syndrome	DOID:0111605	distal arthrogryposis type 2A	DOID:0111604	Freeman-Sheldon syndrome
+MONDO:0008803	Antley-Bixler syndrome	DOID:0050462	Antley-Bixler syndrome with disordered steroidogenesis	DOID:0081289	Antley-Bixler syndrome
+MONDO:0009698	Unverricht-Lundborg syndrome	DOID:0111452	progressive myoclonus epilepsy 1A	DOID:3535	Unverricht-Lundborg syndrome
+MONDO:0011996	chronic myelogenous leukemia, BCR-ABL1 positive	DOID:0081088	chronic myelogenous leukemia, BCR-ABL1 positive	DOID:8552	chronic myeloid leukemia
+MONDO:0012883	acute promyelocytic leukemia	DOID:0081081	acute promyelocytic leukemia with PML-RARA	DOID:0060318	acute promyelocytic leukemia
+MONDO:0013209	metabolic dysfunction-associated steatotic liver disease	DOID:0080546	non-alcoholic fatty liver	DOID:0080208	metabolic dysfunction-associated steatotic liver disease
+MONDO:0014561	3-methylglutaconic aciduria, type VIIB	DOID:0081134	3-methylglutaconic aciduria type 7b	DOID:0110003	3-methylglutaconic aciduria with cataracts, neurologic involvement and neutropenia
+MONDO:0014622	isolated focal non-epidermolytic palmoplantar keratoderma	DOID:0111711	focal nonepidermolytic palmoplantar keratoderma 2	DOID:0111708	focal nonepidermolytic palmoplantar keratoderma
+MONDO:0015131	combined immunodeficiency	DOID:628	combined T cell and B cell immunodeficiency	DOID:0111962	combined immunodeficiency
+MONDO:0016575	primary ciliary dyskinesia	DOID:0050144	Kartagener syndrome	DOID:9562	primary ciliary dyskinesia
+MONDO:0016612	X-linked cerebellar ataxia	DOID:0111828	X-linked cerebellar ataxia	DOID:0050953	X-linked hereditary ataxia
+MONDO:0016700	anaplastic ependymoma	DOID:5889	anaplastic ependymoma	DOID:5074	high grade ependymoma
+MONDO:0019004	kidney Wilms tumor	DOID:5176	renal Wilms' tumor	DOID:2154	nephroblastoma
+MONDO:0019046	leukodystrophy	DOID:0060786	hypomyelinating leukodystrophy	DOID:10579	leukodystrophy
+MONDO:0019118	inherited retinal dystrophy	DOID:8500	hereditary retinal dystrophy	DOID:8501	fundus dystrophy
+MONDO:0020513	spermatocytic seminoma	DOID:7891	testicular spermatocytic seminoma	DOID:5834	spermatocytoma
+MONDO:0005044	hypertensive disorder	ICD10CM:I15	Secondary hypertension	ICD10CM:I10-I16	Hypertensive diseases (I10-I16)
+MONDO:0005178	osteoarthritis	ICD10CM:M19	Other and unspecified osteoarthritis	ICD10CM:M15-M19	Osteoarthritis (M15-M19)
+MONDO:0005385	vascular disorder	ICD10CM:I70-I79	Diseases of arteries, arterioles and capillaries (I70-I79)	ICD10CM:I00-I99	Diseases of the circulatory system (I00-I99)
+MONDO:0024647	urolithiasis	ICD10CM:N21	Calculus of lower urinary tract	ICD10CM:N20-N23	Urolithiasis (N20-N23)
+MONDO:0005579	epilepsy, idiopathic generalized	OMIM:600669	epilepsy, idiopathic generalized	OMIMPS:600669	
+MONDO:0009563	maple syrup urine disease	OMIM:248600	maple syrup urine disease	OMIMPS:248600	
+MONDO:0009696	juvenile myoclonic epilepsy	OMIM:254770	epilepsy, myoclonic juvenile	OMIMPS:254770	
+MONDO:0019200	retinitis pigmentosa	OMIM:268000	retinitis pigmentosa	OMIMPS:268000	
+MONDO:0001748	maxillary sinus carcinoma	NCIT:C9332	Maxillary Sinus Carcinoma	NCIT:C3540	Malignant Maxillary Sinus Neoplasm
+MONDO:0002119	ossifying fibroma	NCIT:C8422	Cemento-Ossifying Fibroma	NCIT:C173820	Ossifying Fibroma
+MONDO:0002142	undifferentiated pleomorphic sarcoma	NCIT:C114541	Adult Undifferentiated Pleomorphic Sarcoma	NCIT:C4247	Undifferentiated Pleomorphic Sarcoma
+MONDO:0004473	epiglottis cancer	NCIT:C35697	Epiglottic Carcinoma	NCIT:C4836	Malignant Epiglottis Neoplasm
+MONDO:0005272	myelodysplastic syndrome with single lineage dysplasia	NCIT:C2872	Refractory Anemia	NCIT:C82591	Myelodysplastic Syndrome, Not Otherwise Specified with Single Lineage Dysplasia
+MONDO:0006490	vaginal squamous cell carcinoma	NCIT:C7736	Vaginal Squamous Cell Carcinoma, Not Otherwise Specified	NCIT:C180915	Vaginal Squamous Cell Carcinoma
+MONDO:0011655	alveolar soft part sarcoma	NCIT:C7943	Adult Alveolar Soft Part Sarcoma	NCIT:C3750	Alveolar Soft Part Sarcoma
+MONDO:0021632	primary brain neoplasm	NCIT:C4952	Localized Brain Neoplasm	NCIT:C170814	Primary Brain Neoplasm
+MONDO:0024477	liver and intrahepatic bile duct neoplasm	NCIT:C7106	Liver Epithelial Neoplasm	NCIT:C7103	Liver Neoplasm
+MONDO:0044792	large congenital melanocytic nevus	NCIT:C4234	Giant Congenital Nevus	NCIT:C3944	Congenital Melanocytic Nevus

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -3,7 +3,8 @@
 Resources
 - GitHub issue: https://github.com/monarch-initiative/mondo-ingest/issues/92
 - GitHub PR: https://github.com/monarch-initiative/mondo-ingest/pull/363
-- Google doc about cases https://docs.google.com/document/d/1H8fJKiKD-L1tfS-2LJu8t0_2YXJ1PQJ_7Zkoj7Vf7xA/edit#heading=h.9hixairfgxa1
+- Google doc about cases
+https://docs.google.com/document/d/1H8fJKiKD-L1tfS-2LJu8t0_2YXJ1PQJ_7Zkoj7Vf7xA/edit#heading=h.9hixairfgxa1
 
 todo's (minor)
  1. Simplify: Set[RELATIONSHIP] _source_edges vars: (sub, rdfs:subClassOf, pred) --> (sub, pred) . This whole pipeline
@@ -51,15 +52,14 @@ from oaklib.interfaces.basic_ontology_interface import RELATIONSHIP
 from oaklib.interfaces.obograph_interface import GraphTraversalMethod
 from oaklib.types import CURIE
 
-from src.scripts.sync_subclassof_collate_self_parentage import collate_self_parentage
-
 HERE = Path(os.path.abspath(os.path.dirname(__file__)))
 SRC_DIR = HERE.parent
 PROJECT_ROOT = SRC_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 from src.scripts.sync_subclassof_collate_direct_in_mondo_only import collate_direct_in_mondo_only
+from src.scripts.sync_subclassof_collate_self_parentage import collate_self_parentage
 from src.scripts.sync_subclassof_config import EX_DEFAULTS, IN_MONDO_ONLY_FILE_STEM, METADATA_DIR, REPORTS_DIR, \
-    ROBOT_SUBHEADER, TMP_DIR, OUTPATH_SELF_PARENTAGE
+    ROBOT_SUBHEADER, TMP_DIR, SELF_PARENTAGE_DEFAULT_FILE_STEM
 from src.scripts.utils import CACHE_DIR, MONDO_PREFIX_MAP, PREFIX_MAP, get_owned_prefix_map
 
 
@@ -150,7 +150,7 @@ def _ancestors(
         # If Mondo, use cache if mondo_24hr_cache=True and cache is indeed <24hrs
         # - either getmtime() for modified or getctime() for created should be sufficient
         if (ontology_name.lower() == 'mondo' and mondo_24hr_cache and
-            os.path.exists(cache_path) and ((time() - os.path.getmtime(cache_path)) / (60 * 60) < 24)):
+                os.path.exists(cache_path) and ((time() - os.path.getmtime(cache_path)) / (60 * 60) < 24)):
             return pickle.load(open(cache_path, 'rb'))
 
         # Execute
@@ -212,7 +212,8 @@ def sync_subclassof(
     mondo_db_path: str = EX_DEFAULTS['mondo_db_path'], mondo_ingest_db_path: str = EX_DEFAULTS['mondo_ingest_db_path'],
     mondo_mappings_path: str = EX_DEFAULTS['mondo_mappings_path'],
     onto_config_path: str = EX_DEFAULTS['onto_config_path'],
-    outpath_direct_in_mondo_only: str = EX_DEFAULTS['outpath_in_mondo_only'], use_cache=False, verbose=True
+    outpath_direct_in_mondo_only: str = EX_DEFAULTS['outpath_direct_in_mondo_only'],
+    outpath_self_parentage: str = EX_DEFAULTS['outpath_self_parentage'], use_cache=False, verbose=True
 ):
     """Run"""
     source_name = os.path.basename(outpath_added).split('.')[0]
@@ -405,19 +406,25 @@ def sync_subclassof(
     # - obsolete cases
     obsoletes = (df3['subject_mondo_label'].str.startswith('obsolete') |
                  df3['object_mondo_label'].str.startswith('obsolete'))
+    # todo: sort_values: from here and below for this section, should remove; should not be necessary
     df3_obs = df3[obsoletes].sort_values(common_sort_cols)
-    # - non-obsolete cases
+    # - filter: non-obsolete cases
     df3 = df3[~obsoletes].sort_values(common_sort_cols)
+    # - self-parentage / proxy merges
+    self_parentage_cases = df3['subject_mondo_id'] == df3['object_mondo_id']
+    df3_self_parentage = df3[self_parentage_cases]
+    sp_err = f'Cases of self-parentage found for source {source_name}. This is a low urgency warning, as these are ' \
+             f'with almost 100% certainty caused by legal Mondo proxy merges.'
+    if len(df3_self_parentage) > 0:
+        logging.warning(sp_err)
+        df3_self_parentage.to_csv(outpath_self_parentage, sep='\t', index=False)
+    # - filter: non-self parentage cases
+    df3 = df3[~self_parentage_cases].sort_values(common_sort_cols)
     # - save
     df3_obs = pd.concat([pd.DataFrame(subheader), df3_obs])
     df3_obs.to_csv(outpath_added_obsolete, sep='\t', index=False)
     df3 = pd.concat([pd.DataFrame(subheader), df3])
     df3.to_csv(outpath_added, sep='\t', index=False)
-    # - issue: Mondo IDs subClassed to themselves. See: https://github.com/monarch-initiative/mondo-ingest/issues/400
-    df3_self_parentage = df3[df3['subject_mondo_id'] == df3['object_mondo_id']]
-    if len(df3_self_parentage) > 0:
-        include_header = not os.path.exists(OUTPATH_SELF_PARENTAGE)
-        df3_self_parentage.to_csv(OUTPATH_SELF_PARENTAGE, sep='\t', index=False, mode='a', header=include_header)
 
     # Case 5: SCR is direct in Mondo, and not in the source at all
     rels_mondo_raw_all: List[RELATIONSHIP] = [x for x in mondo_db.relationships(
@@ -464,9 +471,13 @@ def cli():  # todo: #remove-temp-defaults
              'are confirmed to also exist in the source.')
     parser.add_argument(
         '-M', '--outpath-direct-in-mondo-only', required=False,
-        default=EX_DEFAULTS['outpath_in_mondo_only'],
+        default=EX_DEFAULTS['outpath_direct_in_mondo_only'],
         help='Path to create file for relations for given ontology where direct subclass relation exists only in Mondo'
              ' and not in the source.')
+    parser.add_argument(
+        '-P', '--outpath-self-parentage', required=False,
+        default=EX_DEFAULTS['outpath_self_parentage'],
+        help='Path to for cases where mapped Mondo IDs are subclasses of themselves. Likely cases of proxy merges.')
     parser.add_argument(
         '-o', '--onto-config-path', required=False, default=EX_DEFAULTS['onto_config_path'],
         help='Path to a config `.yml` for the ontology which contains a `base_prefix_map` which contains a '
@@ -491,8 +502,6 @@ def cli():  # todo: #remove-temp-defaults
 
 def run_defaults(use_cache=True):  # todo: #remove-temp-defaults
     """Run with default settings"""
-    if os.path.exists(OUTPATH_SELF_PARENTAGE):
-        os.remove(OUTPATH_SELF_PARENTAGE)
     ontologies = ['ordo', 'doid', 'icd10cm', 'icd10who', 'icd11foundation', 'omim', 'ncit']
     for name in ontologies:
         sync_subclassof(**{
@@ -503,6 +512,7 @@ def run_defaults(use_cache=True):  # todo: #remove-temp-defaults
             'mondo_ingest_db_path': str(TMP_DIR / 'mondo-ingest.db'),
             'mondo_mappings_path': str(TMP_DIR / 'mondo.sssom.tsv'),
             'outpath_direct_in_mondo_only': str(REPORTS_DIR / f'{name}{IN_MONDO_ONLY_FILE_STEM}'),
+            'outpath_self_parentage': str(TMP_DIR / f'{name}{SELF_PARENTAGE_DEFAULT_FILE_STEM}'),
             'use_cache': use_cache
         })
     collate_direct_in_mondo_only()
@@ -511,4 +521,4 @@ def run_defaults(use_cache=True):  # todo: #remove-temp-defaults
 
 if __name__ == '__main__':
     cli()
-    #run_defaults()  # todo: #remove-temp-defaults
+    # run_defaults()  # todo: #remove-temp-defaults

--- a/src/scripts/sync_subclassof_collate_direct_in_mondo_only.py
+++ b/src/scripts/sync_subclassof_collate_direct_in_mondo_only.py
@@ -70,7 +70,6 @@ def cli():
     parser.add_argument(
         '-o', '--outpath', required=False,
         default=REPORTS_DIR / 'sync-subClassOf.direct-in-mondo-only.tsv', help='Path to save output.')
-
     d: Dict = vars(parser.parse_args())
     collate_direct_in_mondo_only(**d)
 

--- a/src/scripts/sync_subclassof_collate_self_parentage.py
+++ b/src/scripts/sync_subclassof_collate_self_parentage.py
@@ -1,10 +1,11 @@
-"""Sync SubClass: Update report for Mondo classes having themselves as parents in the 'added' template."""
+"""Sync SubClass: Report for Mondo classes having themselves as parents in the "added" template (legal proxy merges)."""
 import logging
 import os
 import sys
 from argparse import ArgumentParser
+from glob import glob
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 
@@ -12,39 +13,61 @@ HERE = Path(os.path.abspath(os.path.dirname(__file__)))
 SRC_DIR = HERE.parent
 PROJECT_ROOT = SRC_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
-from src.scripts.sync_subclassof_config import OUTPATH_SELF_PARENTAGE, EX_DEFAULTS
+from src.scripts.sync_subclassof_config import COLLATE_SELF_PARENTAGE_DEFAULT_PATH, EX_DEFAULTS, \
+    SELF_PARENTAGE_DEFAULT_FILE_STEM, TMP_DIR
+DESC = 'Generating report for Mondo classes having themselves as parents in the "added" template (legal proxy merges).'
+
+
+def aggregate_inputs() -> pd.DataFrame:
+    """Aggregate all input files for each source
+    todo: this code is very similar to what's in the other collation script, so I'd like to abstract if possible at
+     some point. Some differences that the other script has, which could be dealt w/ via parameterization:
+      - deletes 2 columns in each loopp
+      - merged field names differ
+    """
+    df = pd.DataFrame()
+    files: List[str] = glob(str(TMP_DIR / f'*{SELF_PARENTAGE_DEFAULT_FILE_STEM}'))
+    if not files:
+        return df
+
+    for file in files:
+        df_i = pd.read_csv(file, sep='\t')
+        # Set initial dataframe for which subsequent ones will be joined
+        if len(df) == 0:
+            df = df_i
+            continue
+        # Concatenate data
+        df = pd.concat([df, df_i])
+    return df
 
 
 def collate_self_parentage(
-        mondo_mappings_path: str = EX_DEFAULTS['mondo_mappings_path'], in_outpath: str = OUTPATH_SELF_PARENTAGE
+    mondo_mappings_path: str = EX_DEFAULTS['mondo_mappings_path'], outpath: str = COLLATE_SELF_PARENTAGE_DEFAULT_PATH
 ):
-    """Update report for Mondo classes having themselves as parents in the 'added' template."""
-    logging.info('Updateing report for Mondo classes having themselves as parents in the "added" template.')
-
-    sssom_df = pd.read_csv(mondo_mappings_path, sep='\t', comment='#')
-    id_label_map: Dict[str, str] = dict(zip(sssom_df['object_id'], sssom_df['object_label']))
-
-    df = pd.read_csv(in_outpath, sep='\t').rename(columns={
-        'subject_mondo_id': 'mondo_id', 'subject_mondo_label': 'mondo_label'})
-    df['subject_source_label'] = df['subject_source_id'].map(id_label_map)
-    df['object_source_label'] = df['object_source_id'].map(id_label_map)
-    df = df[['mondo_id', 'mondo_label', 'subject_source_id', 'subject_source_label', 'object_source_id', 'object_source_label']]
-
-    df.to_csv(in_outpath, sep='\t', index=False)
+    """'Report for Mondo classes having themselves as parents in the "added" template (legal proxy merges)."""
+    logging.info(DESC)
+    df: pd.DataFrame = aggregate_inputs()
+    if len(df) == 0:
+        logging.warning(
+            'collate_self_parentage():'
+            'No inputs detected for collation of "self-parentage" source cases. This is probably the result of '
+            'running this step out of order. This should come at the end of the synchronization (subclass) pipeline, '
+            'after outputs have been generated for each class.')
+        return
+    df.to_csv(outpath, sep='\t', index=False)
 
 
 def cli():
     """Command line interface."""
     parser = ArgumentParser(
-        prog='sync-subclassof: Collate self-parentage issues',
-        description='Update report for Mondo classes having themselves as parents in the "added" template.')
-
+        prog='sync-subclassof: Collate self-parentage cases',
+        description='For: ' + DESC)
     parser.add_argument(
         '-m', '--mondo-mappings-path', required=False, default=EX_DEFAULTS['mondo_mappings_path'],
         help='Path to file containing all known Mondo mappings, in SSSOM format.')
     parser.add_argument(
-        '-o', '--in-outpath', required=False, default=OUTPATH_SELF_PARENTAGE,
-        help='The file containing all of the cases. It will be read as input and updated / saved again.')
+        '-o', '--outpath', required=False,
+        default=TMP_DIR / 'sync-subClassOf.added.self-parentage.tsv', help='Path to save output.')
     d: Dict = vars(parser.parse_args())
     collate_self_parentage(**d)
 

--- a/src/scripts/sync_subclassof_collate_self_parentage.py
+++ b/src/scripts/sync_subclassof_collate_self_parentage.py
@@ -1,0 +1,53 @@
+"""Sync SubClass: Update report for Mondo classes having themselves as parents in the 'added' template."""
+import logging
+import os
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+
+HERE = Path(os.path.abspath(os.path.dirname(__file__)))
+SRC_DIR = HERE.parent
+PROJECT_ROOT = SRC_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+from src.scripts.sync_subclassof_config import OUTPATH_SELF_PARENTAGE, EX_DEFAULTS
+
+
+def collate_self_parentage(
+        mondo_mappings_path: str = EX_DEFAULTS['mondo_mappings_path'], in_outpath: str = OUTPATH_SELF_PARENTAGE
+):
+    """Update report for Mondo classes having themselves as parents in the 'added' template."""
+    logging.info('Updateing report for Mondo classes having themselves as parents in the "added" template.')
+
+    sssom_df = pd.read_csv(mondo_mappings_path, sep='\t', comment='#')
+    id_label_map: Dict[str, str] = dict(zip(sssom_df['object_id'], sssom_df['object_label']))
+
+    df = pd.read_csv(in_outpath, sep='\t').rename(columns={
+        'subject_mondo_id': 'mondo_id', 'subject_mondo_label': 'mondo_label'})
+    df['subject_source_label'] = df['subject_source_id'].map(id_label_map)
+    df['object_source_label'] = df['object_source_id'].map(id_label_map)
+    df = df[['mondo_id', 'mondo_label', 'subject_source_id', 'subject_source_label', 'object_source_id', 'object_source_label']]
+
+    df.to_csv(in_outpath, sep='\t', index=False)
+
+
+def cli():
+    """Command line interface."""
+    parser = ArgumentParser(
+        prog='sync-subclassof: Collate self-parentage issues',
+        description='Update report for Mondo classes having themselves as parents in the "added" template.')
+
+    parser.add_argument(
+        '-m', '--mondo-mappings-path', required=False, default=EX_DEFAULTS['mondo_mappings_path'],
+        help='Path to file containing all known Mondo mappings, in SSSOM format.')
+    parser.add_argument(
+        '-o', '--in-outpath', required=False, default=OUTPATH_SELF_PARENTAGE,
+        help='The file containing all of the cases. It will be read as input and updated / saved again.')
+    d: Dict = vars(parser.parse_args())
+    collate_self_parentage(**d)
+
+
+if __name__ == '__main__':
+    cli()

--- a/src/scripts/sync_subclassof_config.py
+++ b/src/scripts/sync_subclassof_config.py
@@ -13,8 +13,9 @@ REPORTS_DIR = ONTOLOGY_DIR / 'reports'
 TMP_DIR = ONTOLOGY_DIR / 'tmp'
 METADATA_DIR = ONTOLOGY_DIR / 'metadata'
 IN_MONDO_ONLY_FILE_STEM = '.subclass.direct-in-mondo-only.tsv'
+SELF_PARENTAGE_DEFAULT_FILE_STEM = '.subclass.self-parentage.tsv'
 COLLATE_IN_MONDO_ONLY_DEFAULT_PATH = REPORTS_DIR / 'sync-subClassOf.direct-in-mondo-only.tsv'
-OUTPATH_SELF_PARENTAGE = REPORTS_DIR / 'sync-subClassOf.added.self_parentage_issues.tsv'
+COLLATE_SELF_PARENTAGE_DEFAULT_PATH = TMP_DIR / 'sync-subClassOf.added.self-parentage.tsv'
 ROBOT_SUBHEADER = [{
     'subject_mondo_id': 'ID',
     'subject_mondo_label': '',
@@ -24,6 +25,7 @@ ROBOT_SUBHEADER = [{
     'object_mondo_label': '',
 }]
 EX_ONTO_NAME = 'ordo'  # ['ordo', 'doid', 'icd10cm', 'icd10who', 'omim', 'ncit']
+# todo: if not remove, dedupe from/with run_defaults(); maybe a func that returns this dict
 EX_DEFAULTS = {  # todo: #remove-temp-defaults
     'outpath_added': str(REPORTS_DIR / f'{EX_ONTO_NAME}.subclass.added.robot.tsv'),
     'outpath_added_obsolete': str(REPORTS_DIR / f'{EX_ONTO_NAME}.subclass.added-obsolete.robot.tsv'),
@@ -32,6 +34,7 @@ EX_DEFAULTS = {  # todo: #remove-temp-defaults
     'mondo_db_path': str(TMP_DIR / 'mondo.db'),
     'mondo_ingest_db_path': str(TMP_DIR / 'mondo-ingest.db'),
     'mondo_mappings_path': str(TMP_DIR / 'mondo.sssom.tsv'),
-    'outpath_in_mondo_only': str(REPORTS_DIR / f'{EX_ONTO_NAME}{IN_MONDO_ONLY_FILE_STEM}'),
+    'outpath_direct_in_mondo_only': str(REPORTS_DIR / f'{EX_ONTO_NAME}{IN_MONDO_ONLY_FILE_STEM}'),
+    'outpath_self_parentage': str(TMP_DIR / f'{EX_ONTO_NAME}{SELF_PARENTAGE_DEFAULT_FILE_STEM}'),
     'use_cache': False,
 }

--- a/src/scripts/sync_subclassof_config.py
+++ b/src/scripts/sync_subclassof_config.py
@@ -14,6 +14,7 @@ TMP_DIR = ONTOLOGY_DIR / 'tmp'
 METADATA_DIR = ONTOLOGY_DIR / 'metadata'
 IN_MONDO_ONLY_FILE_STEM = '.subclass.direct-in-mondo-only.tsv'
 COLLATE_IN_MONDO_ONLY_DEFAULT_PATH = REPORTS_DIR / 'sync-subClassOf.direct-in-mondo-only.tsv'
+OUTPATH_SELF_PARENTAGE = REPORTS_DIR / 'sync-subClassOf.added.self_parentage_issues.tsv'
 ROBOT_SUBHEADER = [{
     'subject_mondo_id': 'ID',
     'subject_mondo_label': '',


### PR DESCRIPTION
Partially addresses:
- https://github.com/monarch-initiative/mondo-ingest/issues/400

## Overview
This PR introduces reports and/or solutions for situations where the "subclass sync 'added'" pipeline is generating suggested relationships where the Mondo ID is the same for both subject and object.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Build / data PR:
- #524

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes

## Changs
Subclass Sync: Self-parentage
- An issue was reported https://github.com/monarch-initiative/mondo-ingest/issues/400 where the subclass-sync pipeline was generating robot templates with erroneous cases of relationship edges to be added into Mondo, where the subject and object were the same Mondo ID.
- Add: sync-subClassOf.added.self_parentage_issues.tsv and code to generate it.