### PR TITLE
Bug fix: OMIMPS URI prefix

### DIFF
--- a/src/sparql/omim-relevant-diseases.sparql
+++ b/src/sparql/omim-relevant-diseases.sparql
@@ -40,5 +40,5 @@ WHERE {
     }
     
   }
-  FILTER(isIRI(?term) && (regex(str(?term), "https://omim.org/entry/") || regex(str(?term), "https://www.omim.org/phenotypicSeries/")))
+  FILTER(isIRI(?term) && (regex(str(?term), "https://omim.org/entry/") || regex(str(?term), "https://omim.org/phenotypicSeries/")))
 }

--- a/src/sparql/omim-relevant-signature.sparql
+++ b/src/sparql/omim-relevant-signature.sparql
@@ -19,5 +19,5 @@ WHERE {
     }
     
   }
-  FILTER(isIRI(?term) && (regex(str(?term), "https://omim.org/entry/") || regex(str(?term), "https://www.omim.org/phenotypicSeries/")))
+  FILTER(isIRI(?term) && (regex(str(?term), "https://omim.org/entry/") || regex(str(?term), "https://omim.org/phenotypicSeries/")))
 }


### PR DESCRIPTION
> [!WARNING]  
> Depends on:
> - https://github.com/monarch-initiative/omim/pull/109
> 
> See [this comment](https://github.com/monarch-initiative/omim/pull/109#discussion_r1582496380) concerning strategy for doing QC and merging these PRs.

## Overview
Updates OMIM SPARQL files to comply with current URI prefix used elsewhere.

## Build data PR
- #520

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
