### PR TITLE
Update some keys in mondo-match-rules.yaml to conform to latest OAK release

### DIFF
--- a/src/ontology/config/mondo-match-rules.yaml
+++ b/src/ontology/config/mondo-match-rules.yaml
@@ -63,50 +63,50 @@ rules:
       weight: 2.0
 
   # - synonymizer:
-  #     the_rule: Remove parentheses bound info from the label.
+  #     description: Remove parentheses bound info from the label.
   #     match: r'\([^)]*\)'
   #     match_scope: "*"
   #     replacement: ""
 
   - synonymizer:
-      the_rule: Remove box brackets bound info from the label.
+      description: Remove box brackets bound info from the label.
       match: r'\[[^)]*\]'
       match_scope: "*"
       replacement: ""
 
   # - synonymizer:
-  #     the_rule: Remove abbreviations.
+  #     description: Remove abbreviations.
   #     match: r'\b[A-Z][a-zA-Z\.]*[A-Z]\b\.?' [a-zA-Z]*\d
   #     match_scope: "*"
   #     replacement: ""
 
   # - synonymizer:
-  #     the_rule: Remove abbreviations that end with a number in them.
+  #     description: Remove abbreviations that end with a number in them.
   #     match: r'[a-zA-Z]*\d[a-zA-Z]*'
   #     match_scope: "*"
   #     replacement: ""
   
   - synonymizer:
-      the_rule: Broad match terms with the term 'other' in them.
+      description: Broad match terms with the term 'other' in them.
       match: r'(?i)^Other '
       match_scope: "*"
       replacement: ""
       qualifier: "broad"
 
   - synonymizer:
-      the_rule: Replace disease with disorder in the label.
+      description: Replace disease with disorder in the label.
       match: r'disease'
       match_scope: "*"
       replacement: "disorder"
 
   - synonymizer:
-      the_rule: Replace numbers by "type number" in the label.
+      description: Replace numbers by "type number" in the label.
       match: r'(?<!type)\s(\d)'
       match_scope: "*"
       replacement: " type \\1"
 
   - synonymizer:
-      the_rule: Replace "'s" by "s" in the label.
+      description: Replace "'s" by "s" in the label.
       match: r'\'s'
       match_scope: "*"
       replacement: "s"


### PR DESCRIPTION
Resolves https://github.com/INCATools/ontology-access-kit/issues/748

## Overview

This PR:
- Changes a few keys in the synonymizer config file

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [X] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [X] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [X] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [X] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
