### PR TITLE
Bug fix: `pip-bioregistry`

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -427,6 +427,7 @@ tmp/merged.owl: tmp/mondo.owl mondo-ingest.owl tmp/mondo.sssom.ttl
 $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv: $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py tmp/merged.db $(MAPPINGSDIR)/rejected-mappings.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical-2.sssom.tsv
+	$(MAKE) pip-bioregistry
 	python $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py run tmp/merged.db \
 		-c metadata/mondo.sssom.config.yml \
 		-r config/mondo-match-rules.yaml \


### PR DESCRIPTION
## Overview
We removed a `bioregistry` line (https://github.com/monarch-initiative/mondo-ingest/pull/539#discussion_r1628469187) from the makefile because we thought that this was in ODK now. I'm running a build, and it is not present, so I'm adding it back.