### PR TITLE
update for change to MIM(PS) prefix in DOID

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -107,6 +107,7 @@ $(COMPONENTSDIR)/doid.owl: $(TMPDIR)/doid_relevant_signature.txt | component-dow
 		remove -T $(TMPDIR)/doid_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		query \
 			--update ../sparql/fix_omimps.ru \
+			--update ../sparql/fix_mim.ru \
 			--update ../sparql/fix-labels-with-brackets.ru \
 			--update ../sparql/rm_xref_by_prefix.ru \
 			--update ../sparql/fix_make_omim_exact.ru \

--- a/src/sparql/fix_make_omim_exact.ru
+++ b/src/sparql/fix_make_omim_exact.ru
@@ -23,12 +23,12 @@ WHERE
   # Only make the "exactMatch" assumption of 1:1.
   FILTER NOT EXISTS {
   	?cls oboInOwl:hasDbXref ?value2 .
-    FILTER( STRSTARTS(str(?value2), "OMIM"))
+    FILTER( STRSTARTS(str(?value2), "MIM"))
     FILTER(?value!=?value2)
   }
   
-  FILTER( STRSTARTS(str(?value), "OMIM"))
+  FILTER( STRSTARTS(str(?value), "MIM"))
   FILTER( !isBlank(?cls) && STRSTARTS(str(?cls), "http://purl.obolibrary.org/obo/DOID_"))
-  BIND(IRI(REPLACE(REPLACE(STR(?value), "OMIMPS:", "https://omim.org/phenotypicSeries/PS"), "OMIM:", "https://omim.org/entry/")) as ?iri)
+  BIND(IRI(REPLACE(REPLACE(STR(?value), "MIMPS:", "https://omim.org/phenotypicSeries/PS"), "MIM:", "https://omim.org/entry/")) as ?iri)
 
 }

--- a/src/sparql/fix_make_omim_exact.ru
+++ b/src/sparql/fix_make_omim_exact.ru
@@ -23,12 +23,12 @@ WHERE
   # Only make the "exactMatch" assumption of 1:1.
   FILTER NOT EXISTS {
   	?cls oboInOwl:hasDbXref ?value2 .
-    FILTER( STRSTARTS(str(?value2), "MIM"))
+    FILTER( STRSTARTS(str(?value2), "OMIM"))
     FILTER(?value!=?value2)
   }
   
-  FILTER( STRSTARTS(str(?value), "MIM"))
+  FILTER( STRSTARTS(str(?value), "OMIM"))
   FILTER( !isBlank(?cls) && STRSTARTS(str(?cls), "http://purl.obolibrary.org/obo/DOID_"))
-  BIND(IRI(REPLACE(REPLACE(STR(?value), "MIMPS:", "https://omim.org/phenotypicSeries/PS"), "MIM:", "https://omim.org/entry/")) as ?iri)
+  BIND(IRI(REPLACE(REPLACE(STR(?value), "OMIMPS:", "https://omim.org/phenotypicSeries/PS"), "OMIM:", "https://omim.org/entry/")) as ?iri)
 
 }

--- a/src/sparql/fix_mim.ru
+++ b/src/sparql/fix_mim.ru
@@ -24,7 +24,7 @@ WHERE
            owl:annotatedTarget ?value ;
            ?p ?v .
   }
-  FILTER(STRSTARTS(str(?value), "MIM:PS"))
+  FILTER(STRSTARTS(str(?value), "MIM"))
   FILTER (isIRI(?entity))
-  BIND(REPLACE(?value, "MIM:PS", "OMIMPS:", "i") AS ?value_fixed)
+  BIND(REPLACE(?value, "MIM", "OMIM", "i") AS ?value_fixed)
 }

--- a/src/sparql/fix_omimps.ru
+++ b/src/sparql/fix_omimps.ru
@@ -24,7 +24,7 @@ WHERE
            owl:annotatedTarget ?value ;
            ?p ?v .
   }
-  FILTER(STRSTARTS(str(?value), "OMIM:PS"))
+  FILTER(STRSTARTS(str(?value), "MIM:PS"))
   FILTER (isIRI(?entity))
-  BIND(REPLACE(?value, "OMIM:PS", "OMIMPS:", "i") AS ?value_fixed)
+  BIND(REPLACE(?value, "MIM:PS", "MIMPS:", "i") AS ?value_fixed)
 }


### PR DESCRIPTION
Closes #560

## Overview
<!--- A few sentences describing changes / what problem is solved. Should describe the expected result of the changes. 
If applicable, point out the main change that solved the problem, e.g. fixed bug in method xyz. -->
This PR:
Updates the SPARQL queries used in the `components/doid.owl` goal in `mondo-ingest.Makefile` since the Disease Ontology (DOID) now uses the prefixes MIM and MIM:PS for classes.
```
<owl:Class rdf:about="http://purl.obolibrary.org/obo/DOID_0070431">
        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/DOID_0060308"/>
        <obo:IAO_0000115 xml:lang="en">An autosomal recessive intellectual developmental disorder characterized by hyperphosphatasia and intellectual disability. Distinctive facial features including hypertelorism, long palpebral fissures, a nose with a broad bridge and a rounded tip, downturned corners of the mouth, and a thin upper lip are also often observed.</obo:IAO_0000115>
        <oboInOwl:hasDbXref>MESH:C565495</oboInOwl:hasDbXref>
        **<oboInOwl:hasDbXref>MIM:PS239300</oboInOwl:hasDbXref>**
        <oboInOwl:hasDbXref>ORDO:247262</oboInOwl:hasDbXref>
        <oboInOwl:hasDbXref>SNOMEDCT_US_2023_03_01:33982008</oboInOwl:hasDbXref>
        <oboInOwl:hasDbXref>UMLS_CUI:C1855923</oboInOwl:hasDbXref>
        <oboInOwl:hasExactSynonym xml:lang="en">HPMRS</oboInOwl:hasExactSynonym>
        <oboInOwl:hasExactSynonym xml:lang="en">Mabry disease</oboInOwl:hasExactSynonym>
        <oboInOwl:hasExactSynonym xml:lang="en">Mabry syndrome</oboInOwl:hasExactSynonym>
        <oboInOwl:hasExactSynonym xml:lang="en">hyperphosphatasia with mental retardation syndrome</oboInOwl:hasExactSynonym>
        <oboInOwl:hasOBONamespace>disease_ontology</oboInOwl:hasOBONamespace>
        <oboInOwl:id>DOID:0070431</oboInOwl:id>
        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/doid#DO_rare_slim"/>
        <rdfs:label xml:lang="en">hyperphosphatasia with impaired intellectual development syndrome</rdfs:label>
        **<skos:exactMatch>MIM:PS239300</skos:exactMatch>**
        <skos:exactMatch>ORDO:247262</skos:exactMatch>
        <skos:exactMatch>UMLS_CUI:C1855923</skos:exactMatch>
    </owl:Class>
```

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
- [x] --> In progress, will be pushed as branch `issue-560-BUILD-2` and run using `sh run.sh make build-mondo-ingest -B`
   
See:
- #569

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
