### PR TITLE
Update regexes in lexmatch rules

### DIFF
--- a/src/ontology/config/mondo-match-rules.yaml
+++ b/src/ontology/config/mondo-match-rules.yaml
@@ -70,7 +70,7 @@ rules:
 
   - synonymizer:
       description: Remove box brackets bound info from the label.
-      match: r'\[[^)]*\]'
+      match: '\[[^)]*\]'
       match_scope: "*"
       replacement: ""
 
@@ -88,26 +88,26 @@ rules:
   
   - synonymizer:
       description: Broad match terms with the term 'other' in them.
-      match: r'(?i)^Other '
+      match: '(?i)^Other '
       match_scope: "*"
       replacement: ""
       qualifier: "broad"
 
   - synonymizer:
       description: Replace disease with disorder in the label.
-      match: r'disease'
+      match: 'disease'
       match_scope: "*"
       replacement: "disorder"
 
   - synonymizer:
       description: Replace numbers by "type number" in the label.
-      match: r'(?<!type)\s(\d)'
+      match: '(?<!type)\s(\d)'
       match_scope: "*"
       replacement: " type \\1"
 
   - synonymizer:
       description: Replace "'s" by "s" in the label.
-      match: r'\'s'
+      match: "[']s"
       match_scope: "*"
       replacement: "s"
 


### PR DESCRIPTION
With the latest version of OAK (later than ODK 1.5.1) the "Broad match terms with the term 'other' in them." causes a problem (`re.error: global flags not at the start of the expression at position 2`). @cmungall advised that this is not correct yaml syntax (using the "r".

## Overview

This PR:
- Updates the lexmatch rules removing the `r` in front of all match expressions (as per @cmungall advice)
- Updates the `match` clause of the `'s` rule, which was flagged as illegal yaml by my linter

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [X] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [X] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [X] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes

### Additional checklist

- [ ] Needs to be reviewed by @cmungall 
- [ ] Needs to be carefully tested with OAK 0.6.9 (!)

