### PR TITLE
ODK `dev` --> `latest` (`develop`)

### DIFF
--- a/src/ontology/run.sh.conf
+++ b/src/ontology/run.sh.conf
@@ -1,3 +1,3 @@
 ODK_IMAGE=odkfull
-ODK_TAG=dev
+ODK_TAG=latest
 ODK_DEBUG=yes


### PR DESCRIPTION
## Overview
Changes the default ODK version used.

Doing 2 PRs to update make sure that builds off of `main` and development branches both get this change expediently:
- #579
- #580

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [x] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes


Context: [slack](https://monarchinitiative.slack.com/archives/C03AW548J8M/p1718898529277909?thread_ts=1718898311.823059&cid=C03AW548J8M)