### PR TITLE
Add confidence fill conditional in lexmatch compare

### DIFF
--- a/src/scripts/lexmatch-sssom-compare.py
+++ b/src/scripts/lexmatch-sssom-compare.py
@@ -296,6 +296,14 @@ def get_unmapped_df(
     ]
 
     new_df = pd.concat([unmapped_lex_df, unmapped_mondo_df], axis=0)
+    if 'confidence' not in new_df.columns:
+        new_df['confidence'] = 0.5
+    else:
+        new_df['confidence'] = pd.to_numeric(new_df['confidence'], errors='coerce')  # Convert to numeric, invalid parsing will be NaN
+        new_df['confidence'] = new_df['confidence'].apply(lambda x: x if 0 <= x <= 1 else 0.5)  # Replace out of range values with default
+        new_df['confidence'].fillna(0.5, inplace=True)  # Replace NaN with default value
+
+    new_df.to_csv("check_me_out.sssom.tsv", sep="\t")
     filtered_new_df = filter_redundant_rows(new_df)
     return filtered_new_df
 


### PR DESCRIPTION
Currently the filter_redundant_rows in the sssom packages fails when

1. There is a confidence columns and
2. no single value is set

This needs to be fixed in sssom package.

In the meantime, this is a workaround.

Resolves #ISSUE(s).
<!--- "Resolves #ISSUE" will automatically close #ISSUE when the PR is merged. However, if this PR won't 100% address 
the issue and you don't want it to auto-close, you can write one of the following instead of "Resolves"
- Partially addresses
- Addresses sub-task (n) in
-->

## Overview
<!--- A few sentences describing changes / what problem is solved. Should describe the expected result of the changes. 
If applicable, point out the main change that solved the problem, e.g. fixed bug in method xyz. -->
This PR:
- One
- Two
- Three

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [ ] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [ ] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [ ] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
