### PR TITLE
OMIM: Annotated 'included' synonyms using a different property

### DIFF
--- a/src/ontology/config/properties.txt
+++ b/src/ontology/config/properties.txt
@@ -15,6 +15,7 @@ http://www.geneontology.org/formats/oboInOwl#source
 http://www.geneontology.org/formats/oboInOwl#hasSynonymType
 http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty
 http://purl.obolibrary.org/obo/mondo#GENERATED
+http://purl.obolibrary.org/obo/mondo#omim_included
 http://www.w3.org/2004/02/skos/core#broadMatch
 http://www.w3.org/2004/02/skos/core#narrowMatch
 http://www.w3.org/2004/02/skos/core#relatedMatch


### PR DESCRIPTION
Related:
- https://github.com/monarch-initiative/omim/issues/116
- https://github.com/monarch-initiative/omim/issues/117
- Build PR: #617

## Overview
Update: `properties.txt` to list this new annotation property being used by OMIM to denote these special synonyms. This ensures that these properties are not removed during the component OWL creation process.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   

Build PR:
- #617 

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes
