### PR TITLE
`fatal: detected dubious ownership in repository`

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -373,6 +373,7 @@ USE_MONDO_RELEASE=false
 
 # Builds tmp/mondo/ and rebuilds mondo.owl and mondo.sssom.tsv, and stores hash of latest commit of mondo repo main branch in tmp/mondo_repo_built
 tmp/mondo_repo_built:
+	git config --global --add safe.directory /work/src/ontology/tmp/mondo
 	if [ $(USE_MONDO_RELEASE) = true ]; then wget http://purl.obolibrary.org/obo/mondo.owl -O $@; else cd $(TMPDIR) &&\
 		rm -rf ./mondo/ &&\
 		git clone --depth 1 https://github.com/monarch-initiative/mondo &&\
@@ -385,7 +386,8 @@ tmp/mondo_repo_built:
 # Triggers a refresh of tmp/mondo/ and a rebuild of mondo.owl and mondo.sssom.tsv, only if mondo repo main branch has new commits
 .PHONY: refresh-mondo-clone
 refresh-mondo-clone:
-	@if [ ! -d tmp/mondo ]; then \
+	git config --global --add safe.directory /work/src/ontology/tmp/mondo
+	if [ ! -d tmp/mondo ]; then \
 		$(MAKE) tmp/mondo_repo_built -B; \
 	else \
 		current_hash=$$(cat tmp/mondo_repo_built); \


### PR DESCRIPTION
Resolves #633

## Overview
Bug fix for 'fatal: detected dubious ownership in repository'
- Updated 2 related goals in the 'tmp/mondo/ artefacts pipeline'. Added lines which will prevent this error from occurring.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary

Build:
- #636

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
