### PR TITLE
Bug fix: ICD11 "label not found" `RuntimeError`

### DIFF
--- a/src/analysis/problematic_exclusions.py
+++ b/src/analysis/problematic_exclusions.py
@@ -31,13 +31,12 @@ SIGNATURE_FILES_DIR = REPORTS_DIR
 OUTDIR = REPORTS_DIR
 SPARQL_STR_GET_LABELS = """
 {% for sparql_prefix_line in prefixes %}{{ sparql_prefix_line }}{% endfor %}
-prefix owl:  <http://www.w3.org/2002/07/owl#>
-prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-select ?term_id ?term_label where {
+SELECT ?term_id ?term_label WHERE {
     VALUES ?term_id { {{values}} }
-    ?term_id a owl:Class;
-      rdfs:label ?term_label .
+    ?term_id rdfs:label ?term_label .
 }"""
 # # Config
 CONFIG = {
@@ -72,9 +71,8 @@ def load_and_format_tsv(path: str, prefix_map: Dict[str, str]) -> pd.DataFrame:
     return df2
 
 
-# TODO: refactor to use utils.py get_labels()
+# todo: refactor to use utils.py get_labels()
 # todo: In the future, refactor to use OAK.
-#
 # noinspection DuplicatedCode
 def populate_labels(
     df: pd.DataFrame, onto_path: str, prefix_map: Dict[str, str], template_str=SPARQL_STR_GET_LABELS,
@@ -82,7 +80,7 @@ def populate_labels(
 ) -> pd.DataFrame:
     """Get labels for terms
 
-    # TODO: use this when OAK ready
+    # todo: use this when OAK ready
     # from oaklib.resource import OntologyResource
     # from oaklib.implementations.sqldb.sql_implementation import SqlImplementation
     # # https://incatools.github.io/ontology-access-kit/introduction.html#basic-python-example
@@ -105,7 +103,7 @@ def populate_labels(
     terms = [x for x in terms if any([x.startswith(y) for y in prefix_map.keys()])]
 
     # Instantiate template
-    prefix_sparql_strings = [f'prefix {k}: <{v}>' for k, v in prefix_map.items()]
+    prefix_sparql_strings = [f'prefix {k}: <{v}>\n' for k, v in prefix_map.items()]
     template_obj = Template(template_str)
     instantiated_str = template_obj.render(
         prefixes=prefix_sparql_strings,

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -275,7 +275,7 @@ $(REPORTDIR)/%_excluded_terms_in_mondo_xrefs.tsv $(REPORTDIR)/%_excluded_terms_i
 	$(MAKE) up-to-date-mondo.sssom.tsv
 	python3 $(RELEASEDIR)/src/analysis/problematic_exclusions.py \
 	--mondo-mappings-path $(TMPDIR)/mondo.sssom.tsv \
-	--onto-path $(TMPDIR)/component-download-$*.owl.owl \
+	--onto-path $(COMPONENTSDIR)/$*.owl \
 	--onto-config-path metadata/$*.yml \
 	--mirror-signature-path $(REPORTDIR)/mirror_signature-$*.tsv \
 	--component-signature-path $(REPORTDIR)/component_signature-$*.tsv \
@@ -283,7 +283,7 @@ $(REPORTDIR)/%_excluded_terms_in_mondo_xrefs.tsv $(REPORTDIR)/%_excluded_terms_i
 
 # Exclusions: all artefacts for single ontology
 .PHONY: exclusions-%
-exclusions-%: reports/%_exclusion_reasons.ttl reports/%_excluded_terms_in_mondo_xrefs.tsv  $(REPORTDIR)/%_term_exclusions.txt 
+exclusions-%: reports/%_exclusion_reasons.ttl reports/%_excluded_terms_in_mondo_xrefs.tsv  $(REPORTDIR)/%_term_exclusions.txt
 	@echo "$@ completed"
 
 exclusions-all: $(foreach n,$(ALL_COMPONENT_IDS), exclusions-$(n))


### PR DESCRIPTION
## Overview
Fixed bug in the problematic xrefs pipeline where an error would be thrown if there was no ICD11 label. The problem was that (i) the SPARQL query only checked for labels on owl:Class, but not also rdfs:Description, and (ii) `tmp/component-download-*.ow.owl` was being used instead of `components/*.owl`.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Build
- #635 
  - Implementation changed so we'll need to do a new build.

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
