### PR TITLE
account for mirror source content with rdfs:label or skos:prefLabel

### DIFF
--- a/src/analysis/problematic_exclusions.py
+++ b/src/analysis/problematic_exclusions.py
@@ -33,11 +33,16 @@ SPARQL_STR_GET_LABELS = """
 {% for sparql_prefix_line in prefixes %}{{ sparql_prefix_line }}{% endfor %}
 prefix owl:  <http://www.w3.org/2002/07/owl#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
 select ?term_id ?term_label where {
     VALUES ?term_id { {{values}} }
     ?term_id a owl:Class;
-      rdfs:label ?term_label .
+    OPTIONAL {
+        VALUES ?label_property { rdfs:label skos:prefLabel } .
+        ?term_id ?label_property ?term_label .
+        }
+    FILTER(BOUND(?term_label))
 }"""
 # # Config
 CONFIG = {

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -165,7 +165,7 @@ $(COMPONENTSDIR)/icd11foundation.owl: $(TMPDIR)/icd11foundation_relevant_signatu
 	if [ $(COMP) = true ] ; then $(ROBOT) remove -i $(TMPDIR)/component-download-icd11foundation.owl.owl --select imports \
 		rename --mappings config/property-map.sssom.tsv --allow-missing-entities true --allow-duplicates true \
 		rename --mappings config/icd11foundation-property-map.sssom.tsv \
-		remove -T $(TMPDIR)/icd11foundation_relevant_signature.txt --select complement --select "classes individuals" --trim false \
+		remove -T $(TMPDIR)/icd11foundation_relevant_signature.txt --select complement --select "classes individuals" \
 		remove -T $(TMPDIR)/icd11foundation_relevant_signature.txt --select individuals \
 		query \
 			--update ../sparql/fix-labels-with-brackets.ru \


### PR DESCRIPTION
Resolves #ISSUE(s).
<!--- "Resolves #ISSUE" will automatically close #ISSUE when the PR is merged. However, if this PR won't 100% address 
the issue and you don't want it to auto-close, you can write one of the following instead of "Resolves"
- Partially addresses
- Addresses sub-task (n) in
-->

## Overview
<!--- A few sentences describing changes / what problem is solved. Should describe the expected result of the changes. 
If applicable, point out the main change that solved the problem, e.g. fixed bug in method xyz. -->
This PR:
- Updates the SPARQL query to account for mirror source content that uses skos:prefLabel
- Feature branch build https://github.com/monarch-initiative/mondo-ingest/pull/640

- Closes https://github.com/monarch-initiative/mondo-ingest/issues/638

~NOTE: This PR only includes the change to the SPARQL query and not also the change to the icd11.foundation component goal that [removed `--trim false`](https://github.com/monarch-initiative/mondo-ingest/pull/637/files#diff-36e739e129da51616de07dd1ff7ab0c12aa9b5dd45b7f110c9a025fad909ecc4R165).~

We discussed at the Tech call on 16-Aug-2024 that `--trim false` should be removed. This change is now included.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes
