### PR TITLE
Replace `bioregistry` dependency with `curies`

### DIFF
--- a/python-requirements-apple-silicon.txt
+++ b/python-requirements-apple-silicon.txt
@@ -6,7 +6,6 @@ attrs==23.1.0
 Babel==2.13.1
 bcp47==0.0.4
 beautifulsoup4==4.12.2
-bioregistry==0.10.110
 cachetools==5.3.2
 cattrs==23.2.2
 certifi==2023.11.17

--- a/python-requirements-unlocked.txt
+++ b/python-requirements-unlocked.txt
@@ -1,4 +1,3 @@
-bioregistry
 curies
 jinja2
 oaklib>=0.5.20

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -11,7 +11,6 @@ attrs==21.4.0
 Babel==2.10.1
 bcp47==0.0.4
 beautifulsoup4==4.12.2
-bioregistry==0.6.99
 bleach==5.0.0
 cattrs==22.2.0
 certifi==2021.10.8

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -461,7 +461,6 @@ tmp/merged.owl: mondo-ingest.owl tmp/mondo.sssom.ttl tmp/mondo.owl
 $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv: $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py tmp/merged.db $(MAPPINGSDIR)/rejected-mappings.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical.sssom.tsv
 	rm -f $(MAPPINGSDIR)/mondo-sources-all-lexical-2.sssom.tsv
-	$(MAKE) pip-bioregistry
 	python $(SCRIPTSDIR)/match-mondo-sources-all-lexical.py run tmp/merged.db \
 		-c metadata/mondo.sssom.config.yml \
 		-r config/mondo-match-rules.yaml \

--- a/src/scripts/exclusion_table_creation.py
+++ b/src/scripts/exclusion_table_creation.py
@@ -54,11 +54,9 @@ SPARQL_MONDO_EXCLUDES_PATH = os.path.join(SPARQL_DIR, 'mondo-exclusionReason.spa
 
 
 # Functions
-# TODO: evaluate https://github.com/cthoyt/curies , which likely has fully superseded new bioregistry option
-#  https://github.com/biopragmatics/bioregistry/issues/480#issuecomment-1199235747
 def uri_to_curie(uri: str, prefix_map: Dict[str, str]) -> str:
     """Takes an ontological URI and returns a CURIE. Works on the following patterns
-    todo: eventually OAK might also have an optimal solution for this."""
+    todo: migrate usage of this function to curies .compress()"""
     if uri.startswith('<'):
         uri = uri[1:]
     if uri.endswith('>'):

--- a/src/scripts/match-mondo-sources-all-lexical.py
+++ b/src/scripts/match-mondo-sources-all-lexical.py
@@ -30,7 +30,6 @@ from sssom.util import filter_prefixes
 from sssom.parsers import parse_sssom_table
 from sssom.writers import write_table
 from sssom.io import get_metadata_and_prefix_map, filter_file
-from bioregistry import curie_from_iri
 
 SRC = Path(__file__).resolve().parents[1]
 ONTOLOGY_DIR = SRC / "ontology"
@@ -125,6 +124,7 @@ def run(input: str, config: str, rules: str, rejects: str, output: str):
 
     # msdf.prefix_map = sssom_yaml['curie_map']
     # msdf.metadata = sssom_yaml['global_metadata']
+    # todo: if the need for IRI to CURIE conversion rearises, use the curies .compress() instead of bioregistry
     # ! The block below converts IRI into CURIE using bioregistry.
     # msdf.df[SUBJECT_ID] = msdf.df[SUBJECT_ID].apply(
     #     lambda x: iri_to_curie(x) if x.startswith("<http") else x

--- a/src/scripts/unmapped_tables.py
+++ b/src/scripts/unmapped_tables.py
@@ -27,7 +27,7 @@ def create_mapping_status_tables(
 ) -> Dict[str, pd.DataFrame]:
     """Create mapping status tables"""
     # Load sources
-    # - prefix_preplacement_map: Cases where mondo-ingest prefixes differ from bioregistry/OAK, e.g. Orphanet vs ORDO
+    # - prefix_replacement_map: Fixes mondo-ingest prefixes differing from those in packages used (ex: Orphanet vs ORDO)
     # todo: refactor duplicate/similar blocks to a single function
     with open(onto_config_path, 'r') as stream:
         onto_config = yaml.safe_load(stream)


### PR DESCRIPTION
Resolves #584

## Overview
Replace any bioregistry usage with curies instead, and remove any installations of bioregistry.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Build:
- #649 

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes

## Additional info
Didn't find any actual current usages of bioregistry.
There were some comments/todo's referencing bioregistry; updated those to curies.