### PR TITLE
`OMO:0003000` -> `MONDO:ABBREVIATION`

### DIFF
--- a/src/ontology/config/properties.txt
+++ b/src/ontology/config/properties.txt
@@ -26,3 +26,4 @@ rdfs:label
 rdfs:seeAlso
 owl:deprecated
 http://purl.org/dc/terms/description
+http://purl.obolibrary.org/obo/mondo#ABBREVIATION

--- a/src/ontology/config/property-map.sssom.tsv
+++ b/src/ontology/config/property-map.sssom.tsv
@@ -7,4 +7,3 @@ http://www.ebi.ac.uk/efo/reason_for_obsolescence	rdfs:comment
 http://www.ebi.ac.uk/efo/alternative_term	oboInOwl:hasExactSynonym
 http://purl.obolibrary.org/obo/ECO_0000218	oboInOwl:source
 http://purl.obolibrary.org/obo/IAO_0000118	oboInOwl:hasExactSynonym
-http://purl.obolibrary.org/obo/OMO_0003000	http://purl.obolibrary.org/obo/mondo#ABBREVIATION

--- a/src/ontology/config/property-map.sssom.tsv
+++ b/src/ontology/config/property-map.sssom.tsv
@@ -7,3 +7,4 @@ http://www.ebi.ac.uk/efo/reason_for_obsolescence	rdfs:comment
 http://www.ebi.ac.uk/efo/alternative_term	oboInOwl:hasExactSynonym
 http://purl.obolibrary.org/obo/ECO_0000218	oboInOwl:source
 http://purl.obolibrary.org/obo/IAO_0000118	oboInOwl:hasExactSynonym
+http://purl.obolibrary.org/obo/OMO_0003000	http://purl.obolibrary.org/obo/mondo#ABBREVIATION

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -72,6 +72,8 @@ $(COMPONENTSDIR)/omim.owl: $(TMPDIR)/omim_relevant_signature.txt | component-dow
 			--update ../sparql/fix-labels-with-brackets.ru \
 			--update ../sparql/fix_illegal_punning_omim.ru \
 			--update ../sparql/exact_syn_from_label.ru \
+			--update ../sparql/convert-OMO_0003000-to-MONDO_ABBREVIATION.ru \
+		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/omim.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/omim.owl -o $@; fi
 
 # todo: See #1 at top of file

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -73,7 +73,6 @@ $(COMPONENTSDIR)/omim.owl: $(TMPDIR)/omim_relevant_signature.txt | component-dow
 			--update ../sparql/fix_illegal_punning_omim.ru \
 			--update ../sparql/exact_syn_from_label.ru \
 			--update ../sparql/convert-OMO_0003000-to-MONDO_ABBREVIATION.ru \
-		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/omim.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/omim.owl -o $@; fi
 
 # todo: See #1 at top of file

--- a/src/sparql/convert-OMO_0003000-to-MONDO_ABBREVIATION.ru
+++ b/src/sparql/convert-OMO_0003000-to-MONDO_ABBREVIATION.ru
@@ -1,0 +1,18 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+DELETE {
+  ?axiom oboInOwl:hasSynonymType <http://purl.obolibrary.org/obo/OMO_0003000> .
+}
+INSERT {
+  ?axiom oboInOwl:hasSynonymType <http://purl.obolibrary.org/obo/mondo#ABBREVIATION> .
+
+  <http://purl.obolibrary.org/obo/mondo#ABBREVIATION> a owl:AnnotationProperty ;
+    rdfs:subPropertyOf oboInOwl:SynonymTypeProperty .
+}
+WHERE {
+  ?axiom a owl:Axiom ;
+         oboInOwl:hasSynonymType <http://purl.obolibrary.org/obo/OMO_0003000> .
+}


### PR DESCRIPTION
partially resolves #655

## Overview
Adds property map entry to convert `OMO:0003000` -> `MONDO#ABBREVIATION`.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Build PR
- #664

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes
