### PR TITLE
Delete duplicate variable declaration

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -376,7 +376,7 @@ define build_mondo
 	rm -rf ./mondo/ && \
 	git clone --depth 1 https://github.com/monarch-initiative/mondo && \
 	cd mondo/src/ontology && \
-	make mondo.owl mappings -B MIR=false IMP=false MIR=false &&\
+	make mondo.owl mappings -B MIR=false IMP=false &&\
 	latest_hash=$$(git rev-parse origin/master) && \
 	echo "$$latest_hash" > $(1)
 endef

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -322,7 +322,7 @@ def sync_subclassof(
             '\nSee also: https://github.com/monarch-initiative/mondo-ingest/issues/525'
             '\n\nExiting.')
 
-    # Determine hierarchy diferences -----------------------------------------------------------------------------------
+    # Determine hierarchy differences -----------------------------------------------------------------------------------
     # todo: remove unused, commented out vars? (they were created in anticipation of possible cases)
     logging.info('Calculating various differences in hierarchies between source and Mondo')
     # Find which edges appear in both Mondo and source, or only in one or the other


### PR DESCRIPTION
## Overview
Delete duplicate variable declaration in make goal

@matentzn [wrote](https://monarchinitiative.slack.com/archives/C03AW548J8M/p1732615444597049?thread_ts=1732581201.039059&cid=C03AW548J8M):
> Neither mondo.Makefile or Makefile contains the COMP variable, so the second MIR could just be deleted and merged without review and without running QC

@matentzn I could probably just merge this without review but I'm not sure!

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [x] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
