### PR TITLE
Subclass Sync - Direct in source, indirect in Mondo

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -553,7 +553,7 @@ sync: sync-subclassof sync-synonyms
 
 # Synchronization: SubclassOf
 .PHONY: sync-subclassof
-sync-subclassof: $(REPORTDIR)/sync-subClassOf.confirmed.tsv $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv $(TMPDIR)/sync-subClassOf.added.self-parentage.tsv
+sync-subclassof: $(REPORTDIR)/sync-subClassOf.confirmed.tsv $(REPORTDIR)/sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv $(TMPDIR)/sync-subClassOf.added.self-parentage.tsv
 
 # todo: drop this? This is really just an alias here for quality of life, but not used by anything.
 .PHONY: sync-subclassof-%
@@ -570,11 +570,16 @@ $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv: $(foreach n,$(ALL_COMPONE
 $(REPORTDIR)/sync-subClassOf.confirmed.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed.robot.tsv)
 	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(REPORTDIR)/*.subclass.confirmed.robot.tsv > $@
 
-$(REPORTDIR)/%.subclass.confirmed.robot.tsv $(REPORTDIR)/%.subclass.added.robot.tsv $(REPORTDIR)/%.subclass.added-obsolete.robot.tsv $(REPORTDIR)/%.subclass.direct-in-mondo-only.tsv $(TMPDIR)/%.subclass.self-parentage.tsv: $(TMPDIR)/mondo-ingest.db $(TMPDIR)/mondo.db $(TMPDIR)/mondo.sssom.tsv
+# TODO: implement this goal && add to master goal
+$(REPORTDIR)/sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed-direct-source-indirect-mondo.robot.tsv)
+	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(REPORTDIR)/*.subclass.confirmed-direct-source-indirect-mondo.robot.tsv > $@
+
+$(REPORTDIR)/%.subclass.confirmed.robot.tsv $(REPORTDIR)/%.subclass.confirmed-direct-source-indirect-mondo.robot.tsv $(REPORTDIR)/%.subclass.added.robot.tsv $(REPORTDIR)/%.subclass.added-obsolete.robot.tsv $(REPORTDIR)/%.subclass.direct-in-mondo-only.tsv $(TMPDIR)/%.subclass.self-parentage.tsv: $(TMPDIR)/mondo-ingest.db $(TMPDIR)/mondo.db $(TMPDIR)/mondo.sssom.tsv
 	python3 $(SCRIPTSDIR)/sync_subclassof.py \
 	--outpath-added $(REPORTDIR)/$*.subclass.added.robot.tsv \
 	--outpath-added-obsolete $(REPORTDIR)/$*.subclass.added-obsolete.robot.tsv \
 	--outpath-confirmed $(REPORTDIR)/$*.subclass.confirmed.robot.tsv \
+	--outpath-confirmed-direct-source-indirect-mondo $(REPORTDIR)/$*.subclass.confirmed-direct-source-indirect-mondo.robot.tsv \
 	--outpath-direct-in-mondo-only $(REPORTDIR)/$*.subclass.direct-in-mondo-only.tsv \
 	--outpath-self-parentage $(TMPDIR)/$*.subclass.self-parentage.tsv \
 	--mondo-db-path $(TMPDIR)/mondo.db \

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -567,10 +567,10 @@ $(TMPDIR)/sync-subClassOf.added.self-parentage.tsv: $(foreach n,$(ALL_COMPONENT_
 $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.direct-in-mondo-only.tsv) $(TMPDIR)/mondo.db
 	python3 $(SCRIPTSDIR)/sync_subclassof_collate_direct_in_mondo_only.py --outpath $@
 
-$(REPORTDIR)/sync-subClassOf.confirmed.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed.robot.tsv) $(TMPDIR)/mondo.db
+$(REPORTDIR)/sync-subClassOf.confirmed.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed.robot.tsv)
 	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(REPORTDIR)/*.subclass.confirmed.robot.tsv > $@
 
-$(REPORTDIR)/sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed-direct-source-indirect-mondo.robot.tsv) $(TMPDIR)/mondo.db
+$(REPORTDIR)/sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed-direct-source-indirect-mondo.robot.tsv)
 	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(REPORTDIR)/*.subclass.confirmed-direct-source-indirect-mondo.robot.tsv > $@
 
 $(REPORTDIR)/%.subclass.confirmed.robot.tsv $(REPORTDIR)/%.subclass.confirmed-direct-source-indirect-mondo.robot.tsv $(REPORTDIR)/%.subclass.added.robot.tsv $(REPORTDIR)/%.subclass.added-obsolete.robot.tsv $(REPORTDIR)/%.subclass.direct-in-mondo-only.tsv $(TMPDIR)/%.subclass.self-parentage.tsv: $(TMPDIR)/mondo-ingest.db $(TMPDIR)/mondo.db $(TMPDIR)/mondo.sssom.tsv

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -567,11 +567,10 @@ $(TMPDIR)/sync-subClassOf.added.self-parentage.tsv: $(foreach n,$(ALL_COMPONENT_
 $(REPORTDIR)/sync-subClassOf.direct-in-mondo-only.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.direct-in-mondo-only.tsv) $(TMPDIR)/mondo.db
 	python3 $(SCRIPTSDIR)/sync_subclassof_collate_direct_in_mondo_only.py --outpath $@
 
-$(REPORTDIR)/sync-subClassOf.confirmed.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed.robot.tsv)
+$(REPORTDIR)/sync-subClassOf.confirmed.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed.robot.tsv) $(TMPDIR)/mondo.db
 	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(REPORTDIR)/*.subclass.confirmed.robot.tsv > $@
 
-# TODO: implement this goal && add to master goal
-$(REPORTDIR)/sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed-direct-source-indirect-mondo.robot.tsv)
+$(REPORTDIR)/sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(REPORTDIR)/$(n).subclass.confirmed-direct-source-indirect-mondo.robot.tsv) $(TMPDIR)/mondo.db
 	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(REPORTDIR)/*.subclass.confirmed-direct-source-indirect-mondo.robot.tsv > $@
 
 $(REPORTDIR)/%.subclass.confirmed.robot.tsv $(REPORTDIR)/%.subclass.confirmed-direct-source-indirect-mondo.robot.tsv $(REPORTDIR)/%.subclass.added.robot.tsv $(REPORTDIR)/%.subclass.added-obsolete.robot.tsv $(REPORTDIR)/%.subclass.direct-in-mondo-only.tsv $(TMPDIR)/%.subclass.self-parentage.tsv: $(TMPDIR)/mondo-ingest.db $(TMPDIR)/mondo.db $(TMPDIR)/mondo.sssom.tsv

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -225,6 +225,7 @@ def _convert_edge_namespace(
 
 def sync_subclassof(
     outpath_added: str = EX_DEFAULTS['outpath_added'], outpath_confirmed: str = EX_DEFAULTS['outpath_confirmed'],
+    outpath_confirmed_direct_source_indirect_mondo: str = EX_DEFAULTS['outpath_confirmed_direct_source_indirect_mondo'],
     outpath_added_obsolete: str = EX_DEFAULTS['outpath_added_obsolete'],
     mondo_db_path: str = EX_DEFAULTS['mondo_db_path'], mondo_ingest_db_path: str = EX_DEFAULTS['mondo_ingest_db_path'],
     mondo_mappings_path: str = EX_DEFAULTS['mondo_mappings_path'],
@@ -402,8 +403,7 @@ def sync_subclassof(
     _confirmed_df(in_both_direct, outpath_confirmed)
 
     # Case 2: SCR is direct in source, but indirect Mondo
-    _confirmed_df(in_source_direct_mondo_indirect,
-        outpath_confirmed.replace('confirmed', 'confirmed-direct-source-indirect-mondo'))
+    _confirmed_df(in_source_direct_mondo_indirect, outpath_confirmed_direct_source_indirect_mondo)
 
     # Case 3: SCR is direct in the source, but not at all in Mondo
     subheader = deepcopy(ROBOT_SUBHEADER)
@@ -486,8 +486,13 @@ def cli():  # todo: #remove-temp-defaults
              'into Mondo, except for that these terms are obsolete in Mondo.')
     parser.add_argument(
         '-c', '--outpath-confirmed', required=False, default=EX_DEFAULTS['outpath_confirmed'],
-        help='Path to output robot template containing subclass relations for given ontology that exist in Mondo and '
-             'are confirmed to also exist in the source.')
+        help='Path to output robot template containing direct subclass relations for given ontology that exist in '
+             'Mondo and are confirmed to also exist in the source.')
+    parser.add_argument(
+        '-C', '--confirmed-direct-source-indirect-mondo', required=False,
+        default=EX_DEFAULTS['outpath_confirmed_direct_source_indirect_mondo'],
+        help='Path to output robot template containing subclass relations for given ontology that exist in Mondo as '
+             'indirect relations and are confirmed to also exist in the source as direct relations.')
     parser.add_argument(
         '-M', '--outpath-direct-in-mondo-only', required=False,
         default=EX_DEFAULTS['outpath_direct_in_mondo_only'],
@@ -526,6 +531,8 @@ def run_defaults(use_cache=True):  # todo: #remove-temp-defaults
         sync_subclassof(**{
             'outpath_added': str(REPORTS_DIR / f'{name}.subclass.added.robot.tsv'),
             'outpath_confirmed': str(REPORTS_DIR / f'{name}.subclass.confirmed.robot.tsv'),
+            'outpath_confirmed_direct_source_indirect_mondo': \
+                str(REPORTS_DIR / f'{name}.subclass.confirmed-direct-source-indirect-mondo.robot.tsv'),
             'onto_config_path': str(METADATA_DIR / f'{name}.yml'),
             'mondo_db_path': str(TMP_DIR / 'mondo.db'),
             'mondo_ingest_db_path': str(TMP_DIR / 'mondo-ingest.db'),

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -367,6 +367,13 @@ def sync_subclassof(
     in_source_direct_mondo_indirect: List[Dict] = _edges_with_metadata_from_plain_edges(
         in_source_direct_mondo_indirect__source_edges, source_data_map)
 
+    # filter edges with: "disease" or "human disease"
+    filter_terms = ('MONDO:0000001', 'MONDO:0700096')
+    in_source_direct_mondo_indirect = [
+        x for x in in_source_direct_mondo_indirect
+        if x['subject_mondo_id'] not in filter_terms and x['object_mondo_id'] not in filter_terms
+    ]
+
     # - indirect <--> indirect
     #   - Indirect SCRs that exist in both Mondo and source
     # in_both_indirect_mondo_edges: Set[RELATIONSHIP] = (

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -489,7 +489,7 @@ def cli():  # todo: #remove-temp-defaults
         help='Path to output robot template containing direct subclass relations for given ontology that exist in '
              'Mondo and are confirmed to also exist in the source.')
     parser.add_argument(
-        '-C', '--confirmed-direct-source-indirect-mondo', required=False,
+        '-C', '--outpath-confirmed-direct-source-indirect-mondo', required=False,
         default=EX_DEFAULTS['outpath_confirmed_direct_source_indirect_mondo'],
         help='Path to output robot template containing subclass relations for given ontology that exist in Mondo as '
              'indirect relations and are confirmed to also exist in the source as direct relations.')

--- a/src/scripts/sync_subclassof.py
+++ b/src/scripts/sync_subclassof.py
@@ -348,8 +348,8 @@ def sync_subclassof(
     # Find which edges appear in both Mondo and source, or only in one or the other
     # - direct <--> direct
     #   - Direct SCRs exist in both Mondo and source
-    in_both_direct_source_edges: Set[RELATIONSHIP] = rels_direct_source_source.intersection(rels_direct_mondo_source)
-    in_both_direct: List[Dict] = _edges_with_metadata_from_plain_edges(in_both_direct_source_edges, source_data_map)
+    in_both_direct__source_edges: Set[RELATIONSHIP] = rels_direct_source_source.intersection(rels_direct_mondo_source)
+    in_both_direct: List[Dict] = _edges_with_metadata_from_plain_edges(in_both_direct__source_edges, source_data_map)
     #   - Direct SCRs in Mondo which are not direct in source (could be indirect or non-existent)
     # in_mondo_only_direct_source_edges: Set[RELATIONSHIP] = (
     #     rels_direct_mondo_source.difference(rels_direct_source_source))
@@ -361,11 +361,11 @@ def sync_subclassof(
     # in_source_only_direct: List[Dict] = _edges_with_metadata_from_plain_edges(
     #     in_source_only_direct_source_edges, source_data_map)
 
-    # - direct <--> indirect
-    in_source_direct_mondo_indirect_edges: Set[RELATIONSHIP] = \
+    # - direct --> indirect
+    in_source_direct_mondo_indirect__source_edges: Set[RELATIONSHIP] = \
         rels_direct_source_source.intersection(rels_indirect_mondo_source)
     in_source_direct_mondo_indirect: List[Dict] = _edges_with_metadata_from_plain_edges(
-        in_source_direct_mondo_indirect_edges, source_data_map)
+        in_source_direct_mondo_indirect__source_edges, source_data_map)
 
     # - indirect <--> indirect
     #   - Indirect SCRs that exist in both Mondo and source
@@ -383,13 +383,13 @@ def sync_subclassof(
     # in_mondo_only_indirect: List[Dict] = _edges_with_metadata_from_plain_edges(
     #     in_mondo_only_indirect_mondo_edges, mondo_data_map)
 
-    # - direct <--> ancestor
+    # - direct <--> absent
     #   - Direct SCRs in source that don't exist at all in Mondo
-    in_source_direct_not_in_mondo_source_edges = rels_direct_source_source.difference(ancestors_mondo_source)
+    in_source_direct_not_in_mondo__source_edges = rels_direct_source_source.difference(ancestors_mondo_source)
     in_source_direct_not_in_mondo: List[Dict] = _edges_with_metadata_from_plain_edges(
-        in_source_direct_not_in_mondo_source_edges, source_data_map)
+        in_source_direct_not_in_mondo__source_edges, source_data_map)
     #   - Direct SCRs in Mondo that don't exist at all in source
-    in_mondo_direct_not_in_source_mondo_edges: Set[RELATIONSHIP] = (
+    in_mondo_direct_not_in_source__mondo_edges: Set[RELATIONSHIP] = (
         rels_direct_mondo_mondo.difference(ancestors_source_mondo))
     # in_mondo_direct_not_in_source: List[Dict] = _edges_with_metadata_from_plain_edges(
     #     in_mondo_direct_not_in_source_mondo_edges, mondo_data_map)
@@ -459,7 +459,7 @@ def sync_subclassof(
         'UNSUPPORTED-MISSING' if any(x not in mondo_source_map for x in [row['subject_id'], row['object_id']])
         # Supported / Unsupported: Whether edge has a direct or indirect SCR in source
         else 'UNSUPPORTED-SUBCLASS'
-        if (row['subject_id'], 'rdfs:subClassOf', row['object_id']) in in_mondo_direct_not_in_source_mondo_edges
+        if (row['subject_id'], 'rdfs:subClassOf', row['object_id']) in in_mondo_direct_not_in_source__mondo_edges
         else 'SUPPORTED',
         axis=1)
     df5 = df5.sort_values([src_field, 'subject_id', 'object_id'])

--- a/src/scripts/sync_subclassof_config.py
+++ b/src/scripts/sync_subclassof_config.py
@@ -30,6 +30,8 @@ EX_DEFAULTS = {  # todo: #remove-temp-defaults
     'outpath_added': str(REPORTS_DIR / f'{EX_ONTO_NAME}.subclass.added.robot.tsv'),
     'outpath_added_obsolete': str(REPORTS_DIR / f'{EX_ONTO_NAME}.subclass.added-obsolete.robot.tsv'),
     'outpath_confirmed': str(REPORTS_DIR / f'{EX_ONTO_NAME}.subclass.confirmed.robot.tsv'),
+    'outpath_confirmed_direct_source_indirect_mondo': \
+        str(REPORTS_DIR / f'{EX_ONTO_NAME}.subclass.confirmed-direct-source-indirect-mondo.robot.tsv'),
     'onto_config_path': str(METADATA_DIR / f'{EX_ONTO_NAME}.yml'),
     'mondo_db_path': str(TMP_DIR / 'mondo.db'),
     'mondo_ingest_db_path': str(TMP_DIR / 'mondo-ingest.db'),


### PR DESCRIPTION
Resolves #708

## Overview
Added code to implement Subclass Sync "[case 2](https://docs.google.com/document/d/1H8fJKiKD-L1tfS-2LJu8t0_2YXJ1PQJ_7Zkoj7Vf7xA/edit?tab=t.0#heading=h.9hixairfgxa1)": Direct in source, indirect in Mondo.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Mini build:
- #717

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes


## Additional info
I ran output and observed that the case in #708 appeared as expected!:

|subject_mondo_id|subject_mondo_label|object_mondo_id|subject_source_id|object_source_id|object_mondo_label|
|-|-|-|-|-|-|
|ID| |SC %|>A oboInOwl:source| | |
|MONDO:0000248|dengue shock syndrome|MONDO:0005502|DOID:0050125|DOID:12205|dengue disease|

See: Google Sheets:
- [DO](https://docs.google.com/spreadsheets/d/1FUoYJPASTCps55PUCEUtspdY7e5CgSSv245Z_O5SxOk/edit?gid=21333276#gid=21333276)
- [`sync-subClassOf.confirmed-direct-source-indirect-mondo.tsv`](https://docs.google.com/spreadsheets/d/1rAWuzumhr4XEgGOhACsqUQfk3-JiWp8CpTVkbwgProg/edit?gid=1987521551#gid=1987521551)