### PR TITLE
Bug: Synonym Sync: Duplicate rows

### DIFF
--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -172,9 +172,11 @@ def _common_operations(
     # Format
     if not df_is_combined:
         # - Acronyms: Use source case
-        #   This operation prevents capitalization from being lost, as sometimes Mondo has used lowercase.
-        df['synonym'] = df.apply(lambda row:
-            row['synonym_case_source'] if MONDO_ABBREV_URI in row['synonym_type'] else row['synonym'], axis=1)
+        #   This operation prevents capitalization from being lost, as sometimes Mondo has used lowercase. However,
+        #   ignore cases where 'synonym_case_source' is multi-value.
+        df['synonym'] = df.apply(lambda row: row['synonym_case_source']
+            if MONDO_ABBREV_URI in row['synonym_type'] and not row['synonym_case_mondo_is_many']
+            else row['synonym'], axis=1)
         # - Add ROBOT columns for each synonym scope
         synonym_scopes = ['exact', 'broad', 'narrow', 'related']
         for scope in synonym_scopes:

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -171,13 +171,6 @@ def _common_operations(
 
     # Format
     if not df_is_combined:
-        # - Acronyms: Use source case
-        #   This operation prevents capitalization from being lost, as sometimes Mondo has used lowercase. However,
-        #   ignore cases where 'synonym_case_source' is multi-value.
-        df['synonym'] = df.apply(lambda row: row['synonym_case_source']
-            if MONDO_ABBREV_URI in row['synonym_type']
-               and not (bool(row['synonym_case_mondo_is_many']) if 'synonym_case_mondo_is_many' in row else False)
-            else row['synonym'], axis=1)
         # - Add ROBOT columns for each synonym scope
         synonym_scopes = ['exact', 'broad', 'narrow', 'related']
         for scope in synonym_scopes:

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -380,7 +380,6 @@ def sync_synonyms(
         'synonym_x': 'synonym_case_mondo', 'synonym_y': 'synonym_case_source'})  # keep Mondo casing if different
     confirmed_df = confirmed_df[confirmed_df[['mondo_id', 'source_id']].apply(tuple, axis=1).isin(mapping_pairs_set)]
     confirmed_df = _handle_synonym_casing_variations(confirmed_df)
-
     del confirmed_df['mondo_evidence']
     confirmed_df = _common_operations(confirmed_df, outpath_confirmed, mondo_exclusions_df=mondo_exclusions_df)
     confirmed_df['case'] = 'confirmed'

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -175,7 +175,8 @@ def _common_operations(
         #   This operation prevents capitalization from being lost, as sometimes Mondo has used lowercase. However,
         #   ignore cases where 'synonym_case_source' is multi-value.
         df['synonym'] = df.apply(lambda row: row['synonym_case_source']
-            if MONDO_ABBREV_URI in row['synonym_type'] and not row['synonym_case_mondo_is_many']
+            if MONDO_ABBREV_URI in row['synonym_type']
+               and not (bool(row['synonym_case_mondo_is_many']) if 'synonym_case_mondo_is_many' in row else False)
             else row['synonym'], axis=1)
         # - Add ROBOT columns for each synonym scope
         synonym_scopes = ['exact', 'broad', 'narrow', 'related']

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -92,7 +92,7 @@ def _handle_synonym_casing_variations(df: pd.DataFrame) -> pd.DataFrame:
     df['synonym_case_diff_mondo'] = df.apply(lambda row:
         row['synonym_case_mondo'] if row['synonym_case_mondo'] != row['synonym_case_source'] else '', axis=1)
     df['synonym_case_diff_source'] = df.apply(lambda row:
-        row['synonym_case_source'] if row['synonym_case_source'] != row['synonym_case_mondo'] else '', axis=1)\
+        row['synonym_case_source'] if row['synonym_case_source'] != row['synonym_case_mondo'] else '', axis=1)
     # Capitalization variations for single source term synonym: aggregate
     agg_dict: Dict[str, Union[str, Callable]] = {col: 'first' for col in df.columns}
     agg_dict['synonym_case_diff_source'] = '|'.join

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -28,8 +28,15 @@ HEADERS_TO_ROBOT_SUBHEADERS = {
     'synonym_scope_source': '',
     'synonym_scope_mondo': '',
     'synonym': '',
+
+    # TODO temp: Don't know which of these columns I'll keep
+    'synonym_case_mondo': '',
     'synonym_case_diff_mondo': '',
+    'synonym_case_mondo_is_many': '',
+    'synonym_case_source': '',
     'synonym_case_diff_source': '',
+    'synonym_case_source_is_many': '',
+
     'source_id': '',
     'source_label': '',
     'synonym_type': '',
@@ -93,10 +100,59 @@ def _handle_synonym_casing_variations(df: pd.DataFrame) -> pd.DataFrame:
         row['synonym_case_mondo'] if row['synonym_case_mondo'] != row['synonym_case_source'] else '', axis=1)
     df['synonym_case_diff_source'] = df.apply(lambda row:
         row['synonym_case_source'] if row['synonym_case_source'] != row['synonym_case_mondo'] else '', axis=1)
-    # Capitalization variations for single source term synonym: aggregate
+
+    # todo: sorting here useful in the end? if not, drop
+    # sort_cols = [x for x in SORT_COLS if x in df.columns] + ['synonym_case_mondo', 'synonym_case_source', 'synonym_case_diff_source', 'synonym_case_diff_mondo']
+    # sort_cols = [x for x in SORT_COLS if x in df.columns]
+    # df = df.sort_values(by=sort_cols)
+    # a1 = df[df['source_id'] == 'DOID:6262']   # todo tmp
+
+    # Capitalization variations for single source term synonym: drop dupe rows & aggregate
     agg_dict: Dict[str, Union[str, Callable]] = {col: 'first' for col in df.columns}
-    agg_dict['synonym_case_diff_source'] = '|'.join
-    df = df.groupby(['mondo_id', 'source_id', 'synonym'], as_index=False).agg(agg_dict)
+    agg_dict['synonym_case_source'] = '|'.join
+    df = df.groupby(['mondo_id', 'source_id', 'synonym_scope', 'synonym'], as_index=False).agg(agg_dict)
+    # a2 = df[df['source_id'] == 'DOID:6262']  # todo tmp
+    # todo: decide what to do with this col for dupes in the end
+    df['synonym_case_source_is_many'] = df['synonym_case_source'].apply(lambda x: '|' in x)
+    # - Correct synonym_case_diff_source field for these cases
+    df['synonym_case_diff_source'] = df.apply(lambda row: row['synonym_case_source']
+        if row['synonym_case_source_is_many'] else row['synonym_case_diff_source'], axis=1)
+    # x1 = df[df['synonym_case_source_is_many'] == True]  # todo temp
+
+    # Capitalization variations for single Mondo term synonym: keep 2+ rows, but aggregate variations in 'diff' cols
+    # TODO decide what needs to be done here. is this good?
+    # todo: i think 3 lines below can be dropped
+    # counts = df.groupby(['synonym_lower']).size()
+    # df_unique = df[df['synonym_lower'].isin(counts[counts == 1].index)]
+    # df_duplicates = df[df['synonym_lower'].isin(counts[counts > 1].index)]
+    # - Mark which rows have multiple capitalizations
+    counts = df.groupby(['synonym_lower', 'mondo_id', 'source_id', 'synonym_scope']).size()
+    df_unique = df[
+        df.set_index(['synonym_lower', 'mondo_id', 'source_id', 'synonym_scope']).index.isin(counts[counts == 1].index)]
+    df_unique['synonym_case_mondo_is_many'] = False
+    df_duplicates = df[
+        df.set_index(['synonym_lower', 'mondo_id', 'source_id', 'synonym_scope']).index.isin(counts[counts > 1].index)]
+    if len(df_duplicates) > 0:
+        df_duplicates['synonym_case_mondo_is_many'] = True
+        # df_duplicates = df_duplicates.sort_values(by=sort_cols)  # todo: needed?
+        # print('dupes + unique = tot?', len(df_duplicates) + len(df_unique) == len(df))  # todo temp
+        # a3 = df_duplicates[df_duplicates['source_id'] == 'DOID:6262']  # todo tmp
+        # x2 = df_duplicates[df_duplicates['synonym_case_source_is_many'] == True]  # todo temp: n=2 rows (1 case) of 550 rows
+        # df_duplicates = df_duplicates.sort_values(by=['synonym_case_source_is_many'], ascending=False)
+        # df_duplicates.head(10).to_csv('~/Desktop/dupes.csv', index=False)  # todo temp
+        # - Aggregate 'diff' col
+        #   First, create a mapping of the variations for each unique combination
+        variations = df_duplicates.groupby(['synonym_lower', 'mondo_id', 'source_id', 'synonym_scope'])[
+            'synonym_case_mondo'].agg(lambda x: '|'.join(sorted(set(x)))).reset_index()
+        #   Create a dictionary for easy lookup
+        variation_dict = variations.set_index(['synonym_lower', 'mondo_id', 'source_id', 'synonym_scope'])[
+            'synonym_case_mondo'].to_dict()
+        #   Apply this mapping to create the new column
+        df_duplicates['synonym_case_diff_mondo'] = df_duplicates.apply(lambda row:
+            variation_dict[(row['synonym_lower'], row['mondo_id'], row['source_id'], row['synonym_scope'])], axis=1)
+
+    df = pd.concat([df_unique, df_duplicates], ignore_index=True)
+
     return df
 
 


### PR DESCRIPTION
Resolves #684

## Overview
Fixed case in which sources can have multiple synonyms which only vary by capitalization, causing duplicate rows to appear in the results.
We don't consider source capitalization as authoritative, so these variations are only useful for analysis and should not show up as multiple rows to be processed. Thus, we now aggregate capitalization variations into the single column `synonym_case_diff_source`.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary

Builds:    
- #723
- Deprecated & closed: #721

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes

---

Results: [Google Sheet](https://docs.google.com/spreadsheets/d/1ftEZ47-JDe-1Z_fRWyO5NS39qT_-8MZsHXHEKz9aZ9Q/edit?gid=1703187298#gid=1703187298)