### PR TITLE
Bug fix: Synonym Sync: Remove recapitalization of acronyms

### DIFF
--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -171,12 +171,6 @@ def _common_operations(
 
     # Format
     if not df_is_combined:
-        # - Acronyms: Use source case
-        #   This operation prevents capitalization from being lost, as sometimes Mondo has used lowercase. However,
-        #   ignore cases where 'synonym_case_source' is multi-value.
-        df['synonym'] = df.apply(lambda row: row['synonym_case_source']
-            if MONDO_ABBREV_URI in row['synonym_type'] and not row['synonym_case_mondo_is_many']
-            else row['synonym'], axis=1)
         # - Add ROBOT columns for each synonym scope
         synonym_scopes = ['exact', 'broad', 'narrow', 'related']
         for scope in synonym_scopes:
@@ -404,6 +398,12 @@ def sync_synonyms(
     # - leave only synonyms that don't exist on given Mondo IDs
     added_df = _filter_a_by_not_in_b(source_df_with_mondo_ids, mondo_df, ['mondo_id', 'synonym_lower'])
     added_df = added_df[added_df[['mondo_id', 'source_id']].apply(tuple, axis=1).isin(mapping_pairs_set)]
+    # - acronyms: Use source case
+    #   Prevents capitalization from being lost, as sometimes Mondo has used lowercase even for acronyms. However,
+    #   ignore cases where 'synonym_case_source' is multi-value.
+    added_df['synonym'] = added_df.apply(lambda row: row['synonym_case_source']
+        if MONDO_ABBREV_URI in row['synonym_type'] and not row['synonym_case_mondo_is_many']
+        else row['synonym'], axis=1)
     added_df = _common_operations(added_df, outpath_added, mondo_exclusions_df=mondo_exclusions_df)
     added_df['case'] = 'added'
 

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -398,12 +398,6 @@ def sync_synonyms(
     # - leave only synonyms that don't exist on given Mondo IDs
     added_df = _filter_a_by_not_in_b(source_df_with_mondo_ids, mondo_df, ['mondo_id', 'synonym_lower'])
     added_df = added_df[added_df[['mondo_id', 'source_id']].apply(tuple, axis=1).isin(mapping_pairs_set)]
-    # - acronyms: Use source case
-    #   Prevents capitalization from being lost, as sometimes Mondo has used lowercase even for acronyms. However,
-    #   ignore cases where 'synonym_case_source' is multi-value.
-    added_df['synonym'] = added_df.apply(lambda row: row['synonym_case_source']
-        if MONDO_ABBREV_URI in row['synonym_type'] and not row['synonym_case_mondo_is_many']
-        else row['synonym'], axis=1)
     added_df = _common_operations(added_df, outpath_added, mondo_exclusions_df=mondo_exclusions_df)
     added_df['case'] = 'added'
 


### PR DESCRIPTION
## Overview
~Fixed bug where this operation was being done for -updated and -confirmed, but it should only be done for -added.~
Removed this recapitalization.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes
