### PR TITLE
Bug fixes: `synonym_sync_combined_cases.robot.tsv` & build hangs

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -594,11 +594,9 @@ tmp/%-synonyms-scope-type-xref.tsv: $(COMPONENTSDIR)/%.owl
 ../../tests/input/sync_synonym/%-synonyms-scope-type-xref.tsv:
 	$(ROBOT) query -i ../../tests/input/sync_synonym/test_$*.owl --query ../sparql/synonyms-scope-type-xref.sparql $@
 
-# todo: we may remove this output later output for analysis during development; at the end, remove it and its usages
-INPUT_FILES := $(wildcard tmp/synonym_sync_combined_cases_*.tsv)
-$(SYN_SYNC_DIR)/synonym_sync_combined_cases.robot.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(SYN_SYNC_DIR)/$(n)-synonyms.added.robot.tsv)
-	head -n 2 $(firstword $(INPUT_FILES)) > $@
-	for file in $(INPUT_FILES); do \
+$(SYN_SYNC_DIR)/synonym_sync_combined_cases.robot.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(TMPDIR)/synonym_sync_combined_cases_$(n).tsv)
+	head -n 2 $< > $@
+	for file in $^; do \
 		tail -n +3 $$file >> $@; \
 	done
 
@@ -611,7 +609,7 @@ $(SYN_SYNC_DIR)/sync-synonyms.confirmed.robot.tsv: $(foreach n,$(ALL_COMPONENT_I
 $(SYN_SYNC_DIR)/sync-synonyms.updated.robot.tsv: $(foreach n,$(ALL_COMPONENT_IDS), $(SYN_SYNC_DIR)/$(n)-synonyms.updated.robot.tsv)
 	awk '(NR == 1) || (NR == 2) || (FNR > 2)' $(SYN_SYNC_DIR)/*.synonyms.updated.robot.tsv > $@
 
-$(SYN_SYNC_DIR)/%-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/%-synonyms.confirmed.robot.tsv $(SYN_SYNC_DIR)/%-synonyms.updated.robot.tsv: $(TMPDIR)/mondo.sssom.tsv $(COMPONENTSDIR)/%.db metadata/%.yml tmp/mondo-synonyms-scope-type-xref.tsv tmp/%-synonyms-scope-type-xref.tsv | $(SYN_SYNC_DIR)
+$(SYN_SYNC_DIR)/%-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/%-synonyms.confirmed.robot.tsv $(SYN_SYNC_DIR)/%-synonyms.updated.robot.tsv $(TMPDIR)/synonym_sync_combined_cases_%.tsv: $(TMPDIR)/mondo.sssom.tsv $(COMPONENTSDIR)/%.db metadata/%.yml tmp/mondo-synonyms-scope-type-xref.tsv tmp/%-synonyms-scope-type-xref.tsv | $(SYN_SYNC_DIR)
 	python3 $(SCRIPTSDIR)/sync_synonym.py \
 	--mondo-mappings-path $(TMPDIR)/mondo.sssom.tsv \
 	--ontology-db-path $(COMPONENTSDIR)/$*.db \
@@ -621,7 +619,8 @@ $(SYN_SYNC_DIR)/%-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/%-synonyms.confirmed.
 	--onto-config-path metadata/$*.yml \
 	--outpath-added $(SYN_SYNC_DIR)/$*.synonyms.added.robot.tsv \
 	--outpath-confirmed $(SYN_SYNC_DIR)/$*.synonyms.confirmed.robot.tsv \
-	--outpath-updated $(SYN_SYNC_DIR)/$*.synonyms.updated.robot.tsv
+	--outpath-updated $(SYN_SYNC_DIR)/$*.synonyms.updated.robot.tsv \
+   	--outpath-combined $(TMPDIR)/synonym_sync_combined_cases_$*.tsv
 
 ##################################
 ## Externally managed content ####

--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -21,7 +21,6 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from src.scripts.utils import PREFIX_MAP, get_owned_prefix_map
 
 
-# todo: when combined_cases_df no longer necessary, remove 'case'
 HEADERS_TO_ROBOT_SUBHEADERS = {
     'mondo_id': 'ID',
     'mondo_label': '',
@@ -204,16 +203,13 @@ def sync_synonyms(
     ontology_db_path: Union[Path, str], mondo_synonyms_path: Union[Path, str],
     mondo_exclusion_configs: Union[Path, str], onto_synonym_types_path: Union[Path, str],
     mondo_mappings_path: Union[Path, str], onto_config_path: Union[Path, str], outpath_added: Union[Path, str],
-    outpath_confirmed: Union[Path, str], outpath_updated: Union[Path, str], outpath_deleted: Union[Path, str] = None,
-    combined_outpath_template_str='tmp/synonym_sync_combined_cases_{}.tsv'
+    outpath_confirmed: Union[Path, str], outpath_updated: Union[Path, str],
+    outpath_combined: Union[Path, str], outpath_deleted: Union[Path, str] = None,
 ):
     """Create outputs for syncing synonyms between Mondo and its sources.
 
     todo: update when -deleted is reactivated
     :param outpath_deleted: Optional. This case isn't fully fleshed out yet.
-
-    todo: if we decided that this param should stay, set as required CLI/functional param w/ no default value.
-    :param combined_outpath_template_str: Creates an additional file concatenating all case files.
 
     todo: possible refactor: labels: Maybe could be done more cleanly and consistently. At first, wanted to add to both
      source_df and mondo_df, but this caused _x and _y cols during joins, or I would have to join on those cols as well.
@@ -387,15 +383,12 @@ def sync_synonyms(
         deleted_df['case'] = 'deleted'
 
     # Write outputs
-    # todo: temp: combined_cases_df: combine all cases for analysis during development
-    if combined_outpath_template_str:
-        combined_cases_df = pd.concat([confirmed_df, added_df, updated_df, deleted_df], ignore_index=True)\
-            .fillna('')
-        combined_cases_outpath = str(combined_outpath_template_str).format(source_name)
-        combined_cases_df = _common_operations(combined_cases_df, combined_cases_outpath, df_is_combined=True)
-        combined_cases_df['source'] = source_name
-        combined_cases_df = pd.concat([pd.DataFrame([HEADERS_TO_ROBOT_SUBHEADERS]), combined_cases_df])
-        combined_cases_df.to_csv(combined_cases_outpath, sep='\t', index=False)
+    combined_cases_df = pd.concat([confirmed_df, added_df, updated_df, deleted_df], ignore_index=True)\
+        .fillna('')
+    combined_cases_df = _common_operations(combined_cases_df, outpath_combined, df_is_combined=True)
+    combined_cases_df['source'] = source_name
+    combined_cases_df = pd.concat([pd.DataFrame([HEADERS_TO_ROBOT_SUBHEADERS]), combined_cases_df])
+    combined_cases_df.to_csv(outpath_combined, sep='\t', index=False)
 
 
 def cli():
@@ -441,6 +434,9 @@ def cli():
         '-u', '--outpath-updated', required=True,
         help='Path to ROBOT template TSV to create which will contain updates to synonym scope predicate; cases where '
              'the synonym exists in Mondo and on the mapped source term, but the scope predicate is different.')
+    parser.add_argument(
+        '-b', '--outpath-combined', required=True,
+        help='Path to curation file which is a concatenation of all cases.')
     sync_synonyms(**vars(parser.parse_args()))
 
 


### PR DESCRIPTION
Resolves #691

## Overview
Fixes that sometimes `synonym_sync_combined_cases.robot.tsv` would be empty.
Also fixes: Sometimes builds would pause in a particular place until some input was made in the terminal.

## Additional info
**Cause:**
I was just about to start working on #691 when I asked Claude about why my builds were pausing; turns out these are related!

> ```
> for file in ; do \
>   tail -n +3 $file >> reports/sync-synonym/synonym_sync_combined_cases.robot.tsv; \
> done
> ```
> There's no list of files after for `file in -` it's empty. This means the loop will execute zero times, but it still needs to be processed by the shell.
> The `head -n 2` command appears to be dangling without an input:
> `head -n 2  > reports/sync-synonym/synonym_sync_combined_cases.robot.tsv`
> It's waiting for input from stdin, which would cause it to pause until it receives input (or you press Ctrl+D to signal EOF).

This explains why this happened to me usually, Nico sometimes, and Trish never. This doesn't happen unless you run a build on a fresh clone!

**Additional tweaks made**:
The "combined cases" file has become a permanent curation file. It made sense to formalize it as such in this PR. Formalizing it this way also made the bug fix easier to implement.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Build:
- #730

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
