### PR TITLE
Updated bugfix icd11 generated synonyms

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -171,6 +171,7 @@ $(COMPONENTSDIR)/icd11foundation.owl: $(TMPDIR)/icd11foundation_relevant_signatu
 		remove -T $(TMPDIR)/icd11foundation_relevant_signature.txt --select individuals \
 		query \
 			--update ../sparql/exact_syn_from_label.ru \
+			--update ../sparql/fix_icd11_synonyms.ru \
 		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/icd11foundation.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/icd11foundation.owl -o $@; fi
 

--- a/src/sparql/fix_icd11_synonyms.ru
+++ b/src/sparql/fix_icd11_synonyms.ru
@@ -1,0 +1,24 @@
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+# Fix synonym formatting for ICD11 where (MIM ######) or (OMIM ######) is appended to the synonym
+
+DELETE {
+  ?class oboInOwl:hasExactSynonym ?exactSynonym .
+}
+
+INSERT {
+  ?class oboInOwl:hasExactSynonym ?updatedSynonym .
+}
+
+WHERE {
+  # Match exact synonyms containing "(MIM ######)" or "(OMIM ###)"
+  ?class oboInOwl:hasExactSynonym ?exactSynonym .
+  FILTER(regex(str(?exactSynonym), "\\((MIM \\d{6}|OMIM\\s+#\\d{6})\\)"))
+
+  # Remove the "(MIM ######)" or "(OMIM ###)" part
+  BIND(REPLACE(STR(?exactSynonym), "\\s*\\((MIM \\d{6}|OMIM\\s+#\\d{6})\\)", "") AS ?updatedSynonym)
+  
+  # Ensure the updated synonym is different
+  FILTER(?exactSynonym != ?updatedSynonym)
+}
+


### PR DESCRIPTION
Resolves #ISSUE(s).
<!--- "Resolves #ISSUE" will automatically close #ISSUE when the PR is merged. However, if this PR won't 100% address 
the issue and you don't want it to auto-close, you can write one of the following instead of "Resolves"
- Partially addresses
- Addresses sub-task (n) in
-->
Related to https://github.com/monarch-initiative/mondo-ingest/issues/745

Data Build https://github.com/monarch-initiative/mondo-ingest/pull/757

## Overview
<!--- A few sentences describing changes / what problem is solved. Should describe the expected result of the changes. 
If applicable, point out the main change that solved the problem, e.g. fixed bug in method xyz. -->
This PR:
Adds an ICD11 specific synonym processing query to serve as a qc fix for some malformed ICD11 synonyms.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
Full build run in progress.
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes
