### PR TITLE
Fix ORDO mappings query

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -92,6 +92,7 @@ $(COMPONENTSDIR)/ordo.owl: $(TMPDIR)/ordo_relevant_signature.txt config/properti
 			--update ../sparql/ordo-construct-subsets.ru \
 			--update ../sparql/ordo-construct-d2g.ru \
 		query --update ../sparql/ordo-replace-annotation-based-mappings.ru \
+		remove --term oboInOwl:hasDbXref --axioms "annotation" \
 		remove -T $(TMPDIR)/ordo_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/ordo.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/ordo.owl -o $@; fi

--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -91,7 +91,7 @@ $(COMPONENTSDIR)/ordo.owl: $(TMPDIR)/ordo_relevant_signature.txt config/properti
 			--update ../sparql/ordo-construct-subclass-from-part-of.ru \
 			--update ../sparql/ordo-construct-subsets.ru \
 			--update ../sparql/ordo-construct-d2g.ru \
-			--update ../sparql/ordo-replace-annotation-based-mappings.ru \
+		query --update ../sparql/ordo-replace-annotation-based-mappings.ru \
 		remove -T $(TMPDIR)/ordo_relevant_signature.txt --select complement --select "classes individuals" --trim false \
 		remove -T config/properties.txt --select complement --select properties --trim true \
 		annotate --ontology-iri $(URIBASE)/mondo/sources/ordo.owl --version-iri $(URIBASE)/mondo/sources/$(TODAY)/ordo.owl -o $@; fi

--- a/src/sparql/ordo-replace-annotation-based-mappings.ru
+++ b/src/sparql/ordo-replace-annotation-based-mappings.ru
@@ -9,7 +9,7 @@ prefix sssom: <https://w3id.org/sssom/>
 
 DELETE {
   ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 } INSERT {
   ?cls a owl:Class;
       skos:broadMatch ?value .
@@ -23,7 +23,7 @@ DELETE {
     owl:annotatedSource ?cls ;
     owl:annotatedProperty ?mapping ;
     owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 
   FILTER(
     STRSTARTS(STR(?mapping_precision_string), "- NTBT") || 
@@ -34,7 +34,7 @@ DELETE {
 
 DELETE {
   ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 } INSERT {
   ?cls a owl:Class;
       skos:exactMatch ?value .
@@ -48,7 +48,7 @@ DELETE {
     owl:annotatedSource ?cls ;
     owl:annotatedProperty ?mapping ;
     owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 
   FILTER(STRSTARTS(STR(?mapping_precision_string), "E (Exact "))
 };
@@ -57,7 +57,7 @@ DELETE {
 
 DELETE {
   ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 } INSERT {
   ?cls a owl:Class;
       skos:narrowMatch ?value .
@@ -71,7 +71,7 @@ DELETE {
     owl:annotatedSource ?cls ;
     owl:annotatedProperty ?mapping ;
     owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 
   FILTER(
     STRSTARTS(STR(?mapping_precision_string), "BTNT") || 
@@ -83,7 +83,7 @@ DELETE {
 
 DELETE {
   ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 } WHERE {
   VALUES ?mapping { oboInOwl:hasDbXref }
 
@@ -94,7 +94,7 @@ DELETE {
     owl:annotatedSource ?cls ;
     owl:annotatedProperty ?mapping ;
     owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
+    oboInOwl:source ?mapping_precision_string .
 
   FILTER(
     STRSTARTS(STR(?mapping_precision_string), "W (Wrong mapping") ||

--- a/src/sparql/ordo-replace-annotation-based-mappings.ru
+++ b/src/sparql/ordo-replace-annotation-based-mappings.ru
@@ -5,26 +5,7 @@ prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 prefix sssom: <https://w3id.org/sssom/>
 
 
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:broadMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- NTBT (ORPHA code's Narrower Term maps to a Broader Term).\n- Inclusion term (The ORPHA code is included under a ICD10 category and has not its own code)."))
-};
+## Capture broad matches
 
 DELETE {
   ?xref_anno a owl:Axiom ;
@@ -44,71 +25,12 @@ DELETE {
     owl:annotatedTarget ?value ;
     ECO:0000218 ?mapping_precision_string .
 
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- NTBT (ORPHA code's Narrower Term maps to a Broader Term).\n- Attributed (The ICD10 code is attributed by Orphanet)."))
+  FILTER(
+    STRSTARTS(STR(?mapping_precision_string), "- NTBT") || 
+    STRSTARTS(STR(?mapping_precision_string), "NTBT"))
 };
 
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:broadMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "NTBT (ORPHA code's Narrower Term maps to a Broader Term)"))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:broadMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- NTBT (ORPHA code's Narrower Term maps to a Broader Term).\n- Index term (The ORPHA code is listed in the ICD10 Index)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:broadMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- NTBT (ORPHA code's Narrower Term maps to a Broader Term).\n- Specific code (The ORPHA code has its own code in the ICD10)."))
-};
+## Capture exact matches
 
 DELETE {
   ?xref_anno a owl:Axiom ;
@@ -128,71 +50,10 @@ DELETE {
     owl:annotatedTarget ?value ;
     ECO:0000218 ?mapping_precision_string .
 
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "E (Exact mapping: the two concepts are equivalent)"))
+  FILTER(STRSTARTS(STR(?mapping_precision_string), "E (Exact "))
 };
 
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:exactMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- E (Exact mapping: the two concepts are equivalent).\n- Specific code (The ORPHA code has its own code in the ICD10)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:exactMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- E (Exact mapping: the two concepts are equivalent).\n- Index term (The ORPHA code is listed in the ICD10 Index)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:exactMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- E (Exact mapping: the two concepts are equivalent).\n- Inclusion term (The ORPHA code is included under a ICD10 category and has not its own code)."))
-};
+## Capture narrow matches
 
 DELETE {
   ?xref_anno a owl:Axiom ;
@@ -212,15 +73,17 @@ DELETE {
     owl:annotatedTarget ?value ;
     ECO:0000218 ?mapping_precision_string .
 
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "BTNT (ORPHA code's Broader Term maps to a Narrower Term)"))
+  FILTER(
+    STRSTARTS(STR(?mapping_precision_string), "BTNT") || 
+    STRSTARTS(STR(?mapping_precision_string), "- BTNT")
+  )
 };
+
+### Remove wrong / not useful mappings
 
 DELETE {
   ?xref_anno a owl:Axiom ;
     ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:narrowMatch ?value .
 } WHERE {
   VALUES ?mapping { oboInOwl:hasDbXref }
 
@@ -233,173 +96,9 @@ DELETE {
     owl:annotatedTarget ?value ;
     ECO:0000218 ?mapping_precision_string .
 
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- BTNT (ORPHA code's Broader Term maps to a Narrower Term).\n- Specific code (The ORPHA code has its own code in the ICD10)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:narrowMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- BTNT (ORPHA code's Broader Term maps to a Narrower Term).\n- Attributed (The ICD10 code is attributed by Orphanet)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:narrowMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- BTNT (ORPHA code's Broader Term maps to a Narrower Term).\n- Inclusion term (The ORPHA code is included under a ICD10 category and has not its own code)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      skos:narrowMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- BTNT (ORPHA code's Broader Term maps to a Narrower Term).\n- Index term (The ORPHA code is listed in the ICD10 Index)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      sssom:notExactMatch ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "W (Wrong mapping: the two concepts are different)"))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      oboInOwl:hasDbXref ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- ND (not yet decided/unable to decide).\n- Attributed (The ICD10 code is attributed by Orphanet)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      oboInOwl:hasDbXref ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "ND (not yet decided/unable to decide)"))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      oboInOwl:hasDbXref ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- ND (not yet decided/unable to decide).\n- Index term (The ORPHA code is listed in the ICD10 Index)."))
-};
-
-DELETE {
-  ?xref_anno a owl:Axiom ;
-    ECO:0000218 ?mapping_precision_string .
-} INSERT {
-  ?cls a owl:Class;
-      oboInOwl:hasDbXref ?value .
-} WHERE {
-  VALUES ?mapping { oboInOwl:hasDbXref }
-
-  ?cls a owl:Class;
-    ?mapping ?value .
-
-  ?xref_anno a owl:Axiom ;
-    owl:annotatedSource ?cls ;
-    owl:annotatedProperty ?mapping ;
-    owl:annotatedTarget ?value ;
-    ECO:0000218 ?mapping_precision_string .
-
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "- ND (not yet decided/unable to decide).\n- Specific code (The ORPHA code has its own code in the ICD10)."))
+  FILTER(
+    STRSTARTS(STR(?mapping_precision_string), "W (Wrong mapping") ||
+    STRSTARTS(STR(?mapping_precision_string), "- ND (not") ||
+    STRSTARTS(STR(?mapping_precision_string), "ND (not")
+  )
 };

--- a/src/sparql/ordo-replace-annotation-based-mappings.ru
+++ b/src/sparql/ordo-replace-annotation-based-mappings.ru
@@ -10,6 +10,7 @@ prefix sssom: <https://w3id.org/sssom/>
 DELETE {
   ?xref_anno a owl:Axiom ;
     oboInOwl:source ?mapping_precision_string .
+    ?cls ?mapping ?value .
 } INSERT {
   ?cls a owl:Class;
       skos:broadMatch ?value .
@@ -35,6 +36,7 @@ DELETE {
 DELETE {
   ?xref_anno a owl:Axiom ;
     oboInOwl:source ?mapping_precision_string .
+    ?cls ?mapping ?value .
 } INSERT {
   ?cls a owl:Class;
       skos:exactMatch ?value .
@@ -61,6 +63,7 @@ DELETE {
 DELETE {
   ?xref_anno a owl:Axiom ;
     oboInOwl:source ?mapping_precision_string .
+    ?cls ?mapping ?value .
 } INSERT {
   ?cls a owl:Class;
       skos:narrowMatch ?value .
@@ -87,6 +90,7 @@ DELETE {
 DELETE {
   ?xref_anno a owl:Axiom ;
     oboInOwl:source ?mapping_precision_string .
+    ?cls ?mapping ?value .
 } WHERE {
   VALUES ?mapping { oboInOwl:hasDbXref }
 

--- a/src/sparql/ordo-replace-annotation-based-mappings.ru
+++ b/src/sparql/ordo-replace-annotation-based-mappings.ru
@@ -50,7 +50,10 @@ DELETE {
     owl:annotatedTarget ?value ;
     oboInOwl:source ?mapping_precision_string .
 
-  FILTER(STRSTARTS(STR(?mapping_precision_string), "E (Exact "))
+  FILTER(
+    STRSTARTS(STR(?mapping_precision_string), "- E (Exact ") || 
+    STRSTARTS(STR(?mapping_precision_string), "E (Exact ")
+  )
 };
 
 ## Capture narrow matches


### PR DESCRIPTION
ORDO mappings were broken for a while, this commit makes the translation of ORDO xref annotations into SKOS much simpler, and hopefully a little more resilient.

Resolves issue reported by Chris on slack, that the mappings in ORDO looked off.

<!--- "Resolves #ISSUE" will automatically close #ISSUE when the PR is merged. However, if this PR won't 100% address 
the issue and you don't want it to auto-close, you can write one of the following instead of "Resolves"
- Partially addresses
- Addresses sub-task (n) in
-->

## Overview
<!--- A few sentences describing changes / what problem is solved. Should describe the expected result of the changes. 
If applicable, point out the main change that solved the problem, e.g. fixed bug in method xyz. -->
This PR:
- Reduces the size of the query by focusing only on the beginning of the source metadata string provided by ORDO. This ensures that lexical variations that inevitably trickle in are not ignored in the future.
- Replaces the wrong ECO property which has already been mapped to oio:source

One super weird thing I could not get to the bottom of is that I have to run the query in a separate `query` pipe for it to work. If I put it in the first half, it handles half the transformations, the second time the rest. I have not more time to look into this - since it works I am fine with it.

Example output:

```
<!-- http://www.orpha.net/ORDO/Orphanet_100000 -->

    <owl:Class rdf:about="http://www.orpha.net/ORDO/Orphanet_100000">
        <rdfs:subClassOf rdf:resource="http://www.orpha.net/ORDO/Orphanet_100002"/>
        <rdfs:subClassOf rdf:resource="http://www.orpha.net/ORDO/Orphanet_557494"/>
        <oboInOwl:hasDbXref>ICD-10:D36.1</oboInOwl:hasDbXref>
        <oboInOwl:hasDbXref>ICD-11:2F3Y</oboInOwl:hasDbXref>
        <oboInOwl:hasDbXref>ICD10:D36.1</oboInOwl:hasDbXref>
        <oboInOwl:hasDbXref>ICD11:2F3Y</oboInOwl:hasDbXref>
        <oboInOwl:hasDbXref>UMLS:C5681810</oboInOwl:hasDbXref>
        <oboInOwl:hasExactSynonym>Reticular perineurioma</oboInOwl:hasExactSynonym>
        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/mondo#ordo_disorder"/>
        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/mondo#ordo_group_of_disorders"/>
        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/mondo#ordo_subtype_of_a_disorder"/>
        <rdfs:label>Reticular perineurioma</rdfs:label>
        <skos:broadMatch>ICD-11:2F3Y</skos:broadMatch>
        <skos:exactMatch>UMLS:C5681810</skos:exactMatch>
        <skos:narrowMatch>ICD-10:D36.1</skos:narrowMatch>
    </owl:Class>
```

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [X] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
Build PRs:
- #765 
- #766

### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [X] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [X] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
