### PR TITLE
Bug fix: `ModuleNotFoundError`

### DIFF
--- a/src/scripts/sync_synonym_curation_filtering.py
+++ b/src/scripts/sync_synonym_curation_filtering.py
@@ -11,13 +11,12 @@ import pandas as pd
 from oaklib import get_adapter
 from oaklib.types import CURIE, URI
 
-from src.scripts.utils import remove_angle_brackets
-
 HERE = Path(os.path.abspath(os.path.dirname(__file__)))
 SRC_DIR = HERE.parent
 PROJECT_ROOT = SRC_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 from src.scripts.sync_synonym import _common_operations, _read_sparql_output_tsv
+from src.scripts.utils import remove_angle_brackets
 
 
 def _read_synonym_file(path: Union[Path, str], case: str) -> pd.DataFrame:


### PR DESCRIPTION
Fixes a build breaking `ModuleNotFoundError`.

@twhetzel Apologies for just merging this straight away. I need this fix in and it is quick.

I don't know how this slipped in; how we ran build(s) previously without this causing any trouble.