### PR TITLE
Bug fix: `KeyError` on `mondo_label`

### DIFF
--- a/src/sparql/synonyms-scope-type-xref.sparql
+++ b/src/sparql/synonyms-scope-type-xref.sparql
@@ -5,10 +5,12 @@ PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT
-  ?cls_id ?dbXref ?synonym_scope ?synonym (GROUP_CONCAT(DISTINCT STR(?synonym_type_curie); separator="|") as ?synonym_type)
+  ?cls_id ?cls_label ?dbXref ?synonym_scope ?synonym (GROUP_CONCAT(DISTINCT STR(?synonym_type_curie); separator="|") as ?synonym_type)
 WHERE {
   ?cls a owl:Class ;
     ?synonymPropertyUri ?synonym .
+
+  OPTIONAL { ?cls rdfs:label ?cls_label }
 
   OPTIONAL {
     ?axiom owl:annotatedSource ?cls ;
@@ -34,4 +36,4 @@ WHERE {
   # OAK uses oio, so we're doing that here for consistency because we'll be comparing this with OAK output.
   BIND(REPLACE(STR(?synonymPropertyUri), "http://www.geneontology.org/formats/oboInOwl#", "oio:") AS ?synonym_scope)
 }
-GROUP BY ?cls_id ?dbXref ?synonym_scope ?synonym
+GROUP BY ?cls_id ?cls_label ?dbXref ?synonym_scope ?synonym


### PR DESCRIPTION
## Changes
Bug fix: synonyms-scope-type-xref.sparql missing cls_label
This introduced an error later where there was a KeyError on mondo_label (after cls_label was renamed), because it was missing.

---

This is another bug that slipped in, along with #772, from recent PR #751.

I'm really not sure how both of these build-breaking bugs slipped in. I would the previous build(s) for #751 to have failed.

I also need to merge this now, as this is a critical pipeline-breaking bug, and I immediately need to start running stuff on `develop`, so I need this fixed.