### PR TITLE
Docs: linking update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Python is a dev dependency. It's not needed to run the docker containers, but ne
 ### [Workflows](./docs/developer/workflows.md)
 
 ## Reports
-A variety of reports are committed as static files in `src/ontology/reports/`, but some additional reports get rendered 
-into markdown pages as noted below.
+A variety of reports are committed as static files in `src/ontology/reports/` and are documented in the 
+[reports codebook](src/ontology/reports/README.md), but some additional reports get rendered into markdown pages as 
+noted below.
 
 ### Mapping progress report
 The [mapping progress report](./docs/reports/unmapped.md) consists lists of all unmapped terms fo each ontology, as well 


### PR DESCRIPTION
## Overview
Links the codebook in `reports/README.md` to the root `README.md`.

## Pre-merge checklist

### Documentation
Was the documentation added/updated under `docs/`?
- [x] Yes
- [ ] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [x] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
