### PR TITLE
Bug fix: Incorrect paths in synonym sync goal

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -587,10 +587,10 @@ $(SYN_SYNC_DIR):
 sync-synonyms: $(SYN_SYNC_DIR)/sync-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/sync-synonyms.confirmed.robot.tsv $(SYN_SYNC_DIR)/sync-synonyms.updated.robot.tsv $(SYN_SYNC_DIR)/review-qc-duplicate-exact-synonym-no-abbrev.tsv
 
 # Note: If wanting to consider -updated/-scope-mismatch collisions, then: (i) change --dont_filter_updated to False, (ii) add $(SYN_SYNC_DIR)/sync-synonyms.updated.robot.tsv to the list of outputs in the goal definition, (iii) remove the separate goal for $(SYN_SYNC_DIR)/sync-synonyms.updated.robot.tsv.
-$(SYN_SYNC_DIR)/sync-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/review-qc-duplicate-exact-synonym-no-abbrev.tsv: $(TMPDIR)/sync-synonyms.added.robot.tsv $(TMPDIR)/sync-synonyms.confirmed.robot.tsv $(TMPDIR)/sync-synonyms.updated.robot.tsv $(TMPDIR)/mondo-synonyms-scope-type-xref.tsv $(TMPDIR)/mondo.db
+$(SYN_SYNC_DIR)/sync-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/review-qc-duplicate-exact-synonym-no-abbrev.tsv: $(TMPDIR)/sync-synonyms.added.robot.tsv $(SYN_SYNC_DIR)/sync-synonyms.confirmed.robot.tsv $(TMPDIR)/sync-synonyms.updated.robot.tsv $(TMPDIR)/mondo-synonyms-scope-type-xref.tsv $(TMPDIR)/mondo.db
 	python3 $(SCRIPTSDIR)/sync_synonym_curation_filtering.py \
 	--added-inpath $(TMPDIR)/sync-synonyms.added.robot.tsv \
-	--confirmed-inpath $(TMPDIR)/sync-synonyms.confirmed.robot.tsv \
+	--confirmed-inpath $(SYN_SYNC_DIR)/sync-synonyms.confirmed.robot.tsv \
 	--updated-inpath $(TMPDIR)/sync-synonyms.updated.robot.tsv \
 	--added-outpath $(SYN_SYNC_DIR)/sync-synonyms.added.robot.tsv \
 	--updated-outpath $(SYN_SYNC_DIR)/sync-synonyms.updated.robot.tsv \


### PR DESCRIPTION
## Overview
Fixes the following error:
```
python3 ../scripts/sync_synonym.py \
--mondo-mappings-path tmp/mondo.sssom.tsv \
--ontology-db-path components/ordo.db \
--mondo-synonyms-path tmp/mondo-synonyms-scope-type-xref.tsv \
--mondo-exclusion-configs config/mondo-exclusion-configs.yml \
--onto-synonym-types-path tmp/ordo-synonyms-scope-type-xref.tsv \
--onto-config-path metadata/ordo.yml \
--outpath-added tmp/ordo.synonyms.added.robot.tsv \
--outpath-confirmed tmp/ordo.synonyms.confirmed.robot.tsv \
--outpath-updated tmp/ordo.synonyms.updated.robot.tsv \
   	--doid-added-filtration
awk '(NR == 1) || (NR == 2) || (FNR > 2)' tmp/*.synonyms.added.robot.tsv > tmp/sync-synonyms.added.robot.tsv
make[1]: *** No rule to make target 'tmp/sync-synonyms.confirmed.robot.tsv', needed by 'reports/sync-synonym/sync-synonyms.added.robot.tsv'.  Stop.
```

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
