### PR TITLE
`source_metrics.md.j2` documentation correction

### DIFF
--- a/src/ontology/config/source_metrics.md.j2
+++ b/src/ontology/config/source_metrics.md.j2
@@ -36,7 +36,7 @@
 {% for key, value in metrics.axiom_type_count_incl.items() %}| {{ key }} | {{ value }} |
 {% endfor %}
 
-#### Entity namespaces: axiom counts by namespace
+#### Entity namespaces: counts by namespace
 
 | Metric | Value |
 | ------ | ----- |

--- a/src/ontology/config/source_metrics.md.j2
+++ b/src/ontology/config/source_metrics.md.j2
@@ -36,7 +36,7 @@
 {% for key, value in metrics.axiom_type_count_incl.items() %}| {{ key }} | {{ value }} |
 {% endfor %}
 
-#### Entity namespaces: counts by namespace
+#### Entity namespaces: distinct entity count by namespace
 
 | Metric | Value |
 | ------ | ----- |


### PR DESCRIPTION
## Overview
Remove incorrect text in `source_metrics.md.j2`, resulting in confusing description of metrics that could be interpreted as either axioms or entities or both.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [x] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [x] Yes
