### PR TITLE
Version IRI docs

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -334,8 +334,15 @@ metadata/%-metrics.json: $(COMPONENTSDIR)/%.owl
 $(DOCS_DIR)/metrics/%.md: metadata/%-metrics.json | $(DOCS_DIR)/metrics/
 	jinjanate "$(SOURCE_METRICS_TEMPLATE)" metadata/$*-metrics.json > $@
 
+ALL_DBS=$(foreach n,$(ALL_COMPONENT_IDS), $(COMPONENTSDIR)/$(n).db)
+$(REPORTDIR)/iri-sources.txt $(REPORTDIR)/iri-sources.md: $(foreach n,$(ALL_COMPONENT_IDS), $(COMPONENTSDIR)/$(n).db)
+	python3 $(SCRIPTSDIR)/iri_sources.py --rel-paths $(ALL_DBS) --outpath-txt $(REPORTDIR)/iri-sources.txt --outpath-md $(REPORTDIR)/iri-sources.md
+
+.PHONY: iri-docs
+iri-docs: $(REPORTDIR)/iri-sources.md
+
 .PHONY: documentation
-documentation: $(ALL_DOCS) unmapped-terms-docs mapped-deprecated-terms-docs slurp-docs
+documentation: $(ALL_DOCS) unmapped-terms-docs mapped-deprecated-terms-docs slurp-docs iri-docs
 
 
 .PHONY: build-mondo-ingest

--- a/src/ontology/reports/iri-sources.md
+++ b/src/ontology/reports/iri-sources.md
@@ -1,0 +1,12 @@
+These are the versions of the ingested resources that are currently being ingested into Mondo.  
+Note that the specific version listed here might be only partially integrated into Mondo (the integration is ongoing).
+
+##  Versions of ingested resources
+
+- http://purl.obolibrary.org/obo/mondo/sources/2025-04-26/doid.owl
+- http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/icd10cm.owl
+- http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/icd10who.owl
+- http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/icd11foundation.owl
+- http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/ncit.owl
+- http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/omim.owl
+- http://purl.obolibrary.org/obo/mondo/sources/2025-04-26/ordo.owl

--- a/src/ontology/reports/iri-sources.txt
+++ b/src/ontology/reports/iri-sources.txt
@@ -1,0 +1,7 @@
+http://purl.obolibrary.org/obo/mondo/sources/2025-04-26/doid.owl
+http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/icd10cm.owl
+http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/icd10who.owl
+http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/icd11foundation.owl
+http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/ncit.owl
+http://purl.obolibrary.org/obo/mondo/sources/2025-02-26/omim.owl
+http://purl.obolibrary.org/obo/mondo/sources/2025-04-26/ordo.owl

--- a/src/scripts/iri_sources.py
+++ b/src/scripts/iri_sources.py
@@ -1,0 +1,58 @@
+"""Get a list of version IRIs for sources"""
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Dict, List, Union
+
+from oaklib import get_adapter
+from oaklib.implementations import SqlImplementation
+
+HERE = Path(os.path.abspath(os.path.dirname(__file__)))
+SRC_DIR = HERE.parent
+PROJECT_ROOT = SRC_DIR.parent
+ONTO_DIR = PROJECT_ROOT / 'src' / 'ontology'
+
+
+
+def iri_docs(rel_paths: List[str], outpath_txt: Union[Path, str], outpath_md: Union[Path, str]):
+    """Get a list of version IRIs for sources"""
+    version_curies: List[str] = []
+    for rel_path in rel_paths:
+        path = ONTO_DIR / rel_path
+        adapter: SqlImplementation = get_adapter(path)
+        for ont in adapter.ontologies():
+            meta = adapter.ontology_metadata_map(ont)
+            versions: List[str] = meta["owl:versionIRI"]
+            version_curies += versions
+    version_iris = [x.replace('obo:', 'http://purl.obolibrary.org/obo/', ) for x in version_curies]
+
+    outpath_txt = ONTO_DIR / outpath_txt
+    with open(outpath_txt, 'w') as f:
+        for version_iri in version_iris:
+            f.write(version_iri + '\n')
+    outpath_md = ONTO_DIR / outpath_md
+    with open(outpath_md, 'w') as f:
+        f.write(
+"""These are the versions of the ingested resources that are currently being ingested into Mondo.  
+Note that the specific version listed here might be only partially integrated into Mondo (the integration is ongoing).
+
+## Versions of ingested resources\n\n""")
+        for version_iri in version_iris:
+            f.write(f'- {version_iri}\n')
+
+
+def cli():
+    """Command line interface."""
+    parser = ArgumentParser(prog='Source IRI docs', description='Get a list of version IRIs for sources')
+    parser.add_argument(
+        '-p', '--rel-paths', required=True, nargs='+', type=str, help='List of source DB paths, relative to src/ontology/.')
+    parser.add_argument(
+        '-o', '--outpath-txt', required=True, type=str, help='Outpath for text file, relative to src/ontology/.')
+    parser.add_argument(
+        '-O', '--outpath-md', required=True, type=str, help='Outpath for markdown file, relative to src/ontology/.')
+    d: Dict = vars(parser.parse_args())
+    return iri_docs(**d)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
Resolves #833

## Overview
Adds makefile goals, python code, output txt and md: To list all source version IRIs.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [ ] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [ ] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [ ] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
