### PR TITLE
Fix calls to `build_mondo`

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -469,7 +469,7 @@ SKIP_REFRESH=false
 
 $(TMPDIR)/mondo_repo_built: .FORCE
 	@if [ ! -f $@ ]; then \
-		$(call build_mondo, $@); \
+		$(call build_mondo,$(abspath $@)); \
 	elif [ "$(SKIP_REFRESH)" != "true" ]; then \
 		current_hash=$$(cat $@); \
 		cd $(TMPDIR)/mondo; \
@@ -477,7 +477,7 @@ $(TMPDIR)/mondo_repo_built: .FORCE
 		latest_hash=$$(git rev-parse origin/master); \
 		if [ ! "$$current_hash" = "$$latest_hash" ]; then \
 			cd .. && mv mondo mondo-bak && mv mondo_repo_built mondo_repo_built-bak; \
-			cd .. && $(call build_mondo, $@); \
+			cd .. && $(call build_mondo,$(abspath $@)); \
 			rm -rf $(TMPDIR)/mondo-bak $(TMPDIR)/mondo_repo_built-bak; \
 		fi; \
 	fi


### PR DESCRIPTION
Possibly related issue: #619

## Overview
<!--- A few sentences describing changes / what problem is solved. Should describe the expected result of the changes. 
If applicable, point out the main change that solved the problem, e.g. fixed bug in method xyz. -->
`build_mondo` is a function that expects one parameter: a path at which to store the latest commit where the mondo repo was built. This is passed in in the `tmp/mondo_repo_built` recipe as `$@`-- the name of the target. However, the latest hash is stored at that path *after* cd'ing into `./tmp/mondo/src/ontology`, so the `mondo_repo_built` file ends up being redirected to `./tmp/mondo/src/ontology/tmp/mondo_repo_built`.

As a result, `tmp/mondo_repo_built` is never created, and that recipe runs the whole mondo built on every invocation that depends on it. Since that process takes a fair bit of time and resources, it's pretty wasteful.

This commit uses `$(abspath)` to pass an absolute path for `./tmp/mondo_repo_built` on calls to `build_mondo` so that the recipe behaves as expected:
* subsequent calls to `make tmp/mondo_repo_built` check for any new commits to `mondo`, and do nothing if there have been no changes
* subsequent calls to `make tmp/mondo_repo_built SKIP_REFRESH=true` are essentially a noop.

## Pre-merge checklist
<!--- Docs: A common case for documentation is the addition of new `make` goals. Descriptions should be documented for 
new goals both in the (i) `help` command at the bottom of the `mondo-ingest.Makefile` and (ii) 
`docs/developer/workflows.md`. -->

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [x] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
