### PR TITLE
Specify mondo SSSOM target directly

### DIFF
--- a/src/ontology/mondo-ingest.Makefile
+++ b/src/ontology/mondo-ingest.Makefile
@@ -465,7 +465,7 @@ define build_mondo
 	rm -rf ./mondo/ && \
 	git clone --depth 1 https://github.com/monarch-initiative/mondo && \
 	cd mondo/src/ontology && \
-	make mondo.owl mappings -B MIR=false IMP=false &&\
+	make mondo.owl mappings/mondo.sssom.tsv MIR=false IMP=false && \
 	latest_hash=$$(git rev-parse origin/master) && \
 	echo "$$latest_hash" > $(1)
 endef


### PR DESCRIPTION
With https://github.com/monarch-initiative/mondo/pull/9907 merged, the `PHONY` mondo `mappings` target has been split into multiple targets. The only one needed here is `$(MONDO_REPO_BASE)/mappings/mondo.sssom.tsv`. Specifying that target directly avoids doing unnecessary post-processing.

This also removes the `-B` flag from the `make` invocation in the `build_mondo` directive. Since `make` is called there after a fresh `git clone`, `make -B` will never be different from `make`.