### PR TITLE
fix: add owl:Class filter to exact_syn_from_label to avoid annotating…

### DIFF
--- a/src/sparql/exact_syn_from_label.ru
+++ b/src/sparql/exact_syn_from_label.ru
@@ -18,7 +18,8 @@ INSERT {
            owl:annotatedTarget ?label ;
         oboInOwl:hasSynonymType <http://purl.obolibrary.org/obo/mondo#GENERATED_FROM_LABEL> ].
 } WHERE {
-
+  
+  ?cls a owl:Class .
   ?cls rdfs:label ?label .
 
   FILTER NOT EXISTS { ?cls owl:deprecated ?deprecated . }


### PR DESCRIPTION
Resolves #890

## Overview
This PR:
- adds a owl:Class filter to the sparql query in exact_syn_from_label.ru. Only the intended owl:Class should be annotated and some other entity which uses rdf:label (e.g., owl:Ontology) should not be annotated inadvertently

## Pre-merge checklist
N/A

### Documentation
Was the documentation added/updated under `docs/`?
- [ ] Yes
- [x] No, updates to the docs were not necessary after careful consideration

### QC
Was the full pipeline run before submitting this PR using `sh run.sh make build-mondo-ingest` on this branch (after 
`docker pull obolibrary/odkfull:dev`), and no errors occurred?
- [ ] Yes
- [ ] No, there are no functional (code-related) changes to the pipeline in the PR, so no re-run is necessary
- [x] The test suite might be broken (`TypeError: sync_synonyms() got an unexpected keyword argument 'combined_outpath_template_str'`)
   
### New Packages
Were any new *Python packages* added?
- [ ] Yes, [requirements.txt.full](https://github.com/INCATools/ontology-development-kit/blob/master/requirements.txt.full) was updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

Were any other *non-Python packages* added?
- [ ] Yes, [Dockerfile](https://github.com/INCATools/ontology-development-kit/blob/master/Dockerfile) updated and an [ODK issue](https://github.com/INCATools/ontology-development-kit/issues/new) submitted
- [x] No

### PR Review and Conversations Resolved
Has the PR been sufficiently reviewed by at least 1 team member of the Mondo Technical team and all threads resolved?
- [ ] Yes
- [x] No
