### PR TITLE
In synonym sync scripts, give multi-valued cells a deterministic order

### DIFF
--- a/src/scripts/sync_synonym.py
+++ b/src/scripts/sync_synonym.py
@@ -58,8 +58,21 @@ HEADERS_TO_ROBOT_SUBHEADERS = {
     'related_source_id': '>A oboInOwl:hasDbXref',
     'related_synonym_type': '>AI oboInOwl:hasSynonymType SPLIT=|',
 }
+
 SORT_COLS = ['case', 'mondo_id', 'source_id', 'synonym_scope_source', 'synonym_type', 'synonym_type_mondo', 'synonym']
+
 MONDO_ABBREV_URI = 'http://purl.obolibrary.org/obo/mondo#ABBREVIATION'
+
+# Columns whose cells may hold multiple `|`-delimited values in an order that isn't meaningful
+PIPE_DELIMITED_COLS = [
+    'synonym_case_mondo',
+    'synonym_case_source',
+    'synonym_case_diff_mondo',
+    'synonym_case_diff_source',
+    'synonym_type',
+    'synonym_type_internal',
+    'synonym_type_mondo',
+]
 
 
 def _query_synonyms(ids: List[CURIE], db: SqlImplementation) -> pd.DataFrame:
@@ -134,9 +147,7 @@ def _handle_synonym_casing_variations(df: pd.DataFrame) -> pd.DataFrame:
 
     df = pd.concat([df_unique, df_duplicates], ignore_index=True)
 
-    # Sort
-    for col in ['synonym_case_mondo', 'synonym_case_source']:
-        df[col] = df[col].apply(lambda x: '|'.join(sorted(x.split('|'))))
+    # note: multi-valued cells are sorted in _common_operations(), after all derived cols exist
 
     return df
 
@@ -188,13 +199,26 @@ def _handle_internal_synonym_types(df, internal_types=["http://purl.obolibrary.o
     return df
 
 
+def _sort_delimited_values(df: pd.DataFrame, cols: List[str] = PIPE_DELIMITED_COLS, delim='|') -> pd.DataFrame:
+    """Impose a stable order on multi-valued cells.
+
+    Upstream sources of multiple values (SPARQL GROUP_CONCAT & pandas groupby) do not have deterministic ordering.
+    Without this function, the same content will serialise differently between runs, creating noise in data releases.
+    """
+    for col in cols:
+        if col in df.columns:
+            df[col] = df[col].fillna('').apply(
+                lambda x: delim.join(sorted(x.split(delim))) if x else x)
+    return df
+
+
 def _common_operations(
     df: pd.DataFrame, outpath: Union[Path, str], order_cols: List[str] = list(HEADERS_TO_ROBOT_SUBHEADERS.keys()),
     sort_cols: List[str] = SORT_COLS, mondo_exclusions_df=pd.DataFrame(), save=True, dont_make_scope_cols=False
 ) -> pd.DataFrame:
     """Merges synonym types, filters exclusions, does some formatting, and optionally saves.
 
-    Formatting: Add columns, format column order and sorting, drop any superfluous columns.
+    Formatting: Add columns, sort multi-valued cells, format column order and sorting, drop any superfluous columns.
 
     :param: df_is_combined: At the end, we combine all cases into a single file. But for this combined case, we want to
      skip certain operations.
@@ -210,6 +234,9 @@ def _common_operations(
     # Format
     # - Internal synonym types: Things we don't want to add to Mondo, but want to retain in the sync file
     df = _handle_internal_synonym_types(df)
+    # - Stable order within multi-valued cells: must run after all derived cols exist, and before the
+    #   scope cols copy 'synonym_type' and before the row sort, which sorts on it.
+    df = _sort_delimited_values(df)
     if not dont_make_scope_cols:
         # - Add ROBOT columns for each synonym scope
         synonym_scopes = ['exact', 'broad', 'narrow', 'related']
@@ -388,7 +415,8 @@ def sync_synonyms(
     # - add evidence column
     mondo_evidence_lookup: Dict[Tuple, List[str]] = mondo_df.groupby(
         ['mondo_id', 'synonym_scope', 'synonym'])['source_id'].agg(list).to_dict()
-    mondo_evidence_lookup: Dict[Tuple, str] = {k: ', '.join(v) for k, v in mondo_evidence_lookup.items()}
+    #   sorted: `agg(list)` follows mondo_df row order, i.e. SPARQL result order, which isn't stable between runs
+    mondo_evidence_lookup: Dict[Tuple, str] = {k: ', '.join(sorted(v)) for k, v in mondo_evidence_lookup.items()}
     mondo_evidence_rows: List[List[str]] = []
     for k, v in mondo_evidence_lookup.items():
         mondo_evidence_rows.append(list(k) + [v])

--- a/src/scripts/sync_synonym_curation_filtering.py
+++ b/src/scripts/sync_synonym_curation_filtering.py
@@ -14,7 +14,12 @@ HERE = Path(os.path.abspath(os.path.dirname(__file__)))
 SRC_DIR = HERE.parent
 PROJECT_ROOT = SRC_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
-from src.scripts.sync_synonym import _common_operations, _read_sparql_output_tsv, _curies_to_uris_from_delim_str
+from src.scripts.sync_synonym import (
+    _common_operations,
+    _read_sparql_output_tsv,
+    _curies_to_uris_from_delim_str,
+    _sort_delimited_values
+)
 from src.scripts.utils import remove_angle_brackets
 
 
@@ -123,6 +128,8 @@ def sync_synonyms_curation_filtering(
         df_review = df_review[['synonym', 'mondo_id', 'source_id', 'case', 'synonym_type',
             'filtered_because_this_mondo_id_already_has_this_synonym_as_its_label']]\
         .sort_values(['synonym', 'mondo_id'])
+    # - Some multi-valued cells are built via `set()`, which does not have deterministic ordering.
+    df_review = _sort_delimited_values(df_review, cols=['synonym_type'])
     df_review.to_csv(review_outpath, sep='\t', index=False)
     # - filtered outputs
     key_columns = ['synonym', 'mondo_id', 'source_id']

--- a/tests/test_sync_synonym.py
+++ b/tests/test_sync_synonym.py
@@ -42,7 +42,7 @@ import pandas as pd
 TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
 PROJECT_ROOT = TEST_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
-from src.scripts.sync_synonym import sync_synonyms
+from src.scripts.sync_synonym import PIPE_DELIMITED_COLS, _sort_delimited_values, sync_synonyms
 
 ONTO_DIR = PROJECT_ROOT / 'src' / 'ontology'
 META_DIR = ONTO_DIR / 'metadata'
@@ -85,7 +85,6 @@ class TestSyncSynonyms(unittest.TestCase):
             outpath_confirmed=OUTPUT_CONFIRMED,
             # outpath_deleted=OUTPUT_DELETED,
             outpath_updated=OUTPUT_UPDATED,
-            combined_outpath_template_str=None
         )
         cls.df_lookup: Dict[str, pd.DataFrame] = {
             'added': cls._read_df(OUTPUT_ADDED),
@@ -312,3 +311,37 @@ class TestSyncSynonyms(unittest.TestCase):
             'synonym': 'Unmapped: Synonym exists in 1 source and 1 Mondo term, but no mapping',
             'source_id': 'OMIM:999999',
         })
+
+    def test_multi_valued_cells_are_sorted(self):
+        """Multi-valued cells must be sorted"""
+        col_delims: Dict[str, str] = {col: '|' for col in PIPE_DELIMITED_COLS}
+        col_delims['mondo_evidence'] = ', '
+        for template, df in self.df_lookup.items():
+            if len(df) == 0:
+                continue
+            for col, delim in [(k, v) for k, v in col_delims.items() if k in df.columns]:
+                for val in df[col].drop(0).fillna(''):  # drop(0): the ROBOT subheader row
+                    if not val or delim not in val:
+                        continue
+                    vals: List[str] = val.split(delim)
+                    self.assertEqual(sorted(vals), vals, f'Unsorted cell in {template}.{col}: {val}')
+
+
+class TestSortDelimitedValues(unittest.TestCase):
+    """Tests for _sort_delimited_values()"""
+
+    def test_sorts_only_known_cols(self):
+        """Sorts the multi-valued cols it is given, and leaves everything else alone."""
+        df = pd.DataFrame([
+            {'synonym_case_source': 'Del(16)|del(16)', 'synonym': 'b|a'},
+            {'synonym_case_source': 'del(16)|Del(16)', 'synonym': 'b|a'},
+        ])
+        df = _sort_delimited_values(df, cols=['synonym_case_source'])
+        self.assertEqual(['Del(16)|del(16)', 'Del(16)|del(16)'], list(df['synonym_case_source']))
+        self.assertEqual(['b|a', 'b|a'], list(df['synonym']))
+
+    def test_handles_empty_and_missing(self):
+        """Empty cells, NaN, and absent columns are all no-ops."""
+        df = pd.DataFrame([{'synonym_type': ''}, {'synonym_type': None}, {'synonym_type': 'b|a'}])
+        df = _sort_delimited_values(df, cols=['synonym_type', 'col_that_does_not_exist'])
+        self.assertEqual(['', '', 'a|b'], list(df['synonym_type']))


### PR DESCRIPTION
There was a good deal of churn in data releases caused solely by non-meaningful re-ordering of multi-valued cells in TSV that were generated from SPARQL and Pandas groupings, neither of which are guaranteed to be identical across runs. This commit explicitly sorts those values.

Fixes the issue raised in this comment: <https://github.com/monarch-initiative/mondo-ingest/pull/910#issuecomment-5028486391>